### PR TITLE
1.0.2 — remove leftover "Meal" entities from older versions

### DIFF
--- a/custom_components/philips_pet_series/__init__.py
+++ b/custom_components/philips_pet_series/__init__.py
@@ -614,6 +614,10 @@ def _async_remove_stale_entities(hass: HomeAssistant, entry: ConfigEntry) -> Non
         if (
             registry_entry.unique_id.endswith(stale_suffixes)
             or registry_entry.unique_id in stale_unique_ids
+            # Per-meal sensors stopped being created before 1.0.0; upgrades from
+            # older versions still carry them as unavailable "Meal" entities.
+            # Scheduled meals are exposed through the meal calendar instead.
+            or registry_entry.unique_id.startswith("meal_")
         ):
             _LOGGER.debug("Removing stale entity %s", registry_entry.entity_id)
             registry.async_remove(registry_entry.entity_id)

--- a/custom_components/philips_pet_series/manifest.json
+++ b/custom_components/philips_pet_series/manifest.json
@@ -13,5 +13,5 @@
     "petsseries==1.0.0",
     "tuya-mobile>=1.0.0"
   ],
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/custom_components/philips_pet_series/sensor.py
+++ b/custom_components/philips_pet_series/sensor.py
@@ -515,64 +515,6 @@ class PhilipsPetsSeriesEventSensor(PhilipsPetsSeriesEntity, RestoreSensor):
         return super().available and self.coordinator.last_update_success
 
 
-class PhilipsPetsSeriesMealSensor(CoordinatorEntity, SensorEntity):
-    """Representation of a Philips Pets Series Meal Sensor."""
-
-    def __init__(self, coordinator, meal):
-        """Initialize the meal sensor."""
-        super().__init__(coordinator)
-        self.meal = meal
-        self._attr_unique_id = f"meal_{meal.id}"
-        self._attr_name = meal.name
-        self._attr_icon = "mdi:food"
-
-    @property
-    def device_info(self):
-        """Return device information."""
-        # Find the device this meal belongs to
-        device = next(
-            (d for d in self.coordinator.data.get("devices", []) if d.id == self.meal.device_id),
-            None
-        )
-
-        identifiers = {(DOMAIN, self.meal.device_id)}
-
-        # If we found the device, we can try to find the home it belongs to for via_device
-        # But efficiently, we just need to link to the device ID.
-        # Home Assistant links entities to devices via identifiers.
-
-        if device:
-             return DeviceInfo(
-                identifiers=identifiers,
-                name=device.name,
-                manufacturer="Philips",
-                model=device.product_ctn,
-                sw_version=device.product_id,
-                # via_device is optional if we share identifiers with the main device entity
-            )
-
-        return DeviceInfo(
-            identifiers=identifiers,
-            name=f"Device {self.meal.device_id}",
-            manufacturer="Philips",
-        )
-
-    @property
-    def state(self):
-        """Return the next scheduled time of the meal."""
-        return self.meal.feed_time
-
-    @property
-    def extra_state_attributes(self):
-        """Return extra attributes of the meal."""
-        return {
-            "portion_amount": self.meal.portion_amount,
-            "repeat_days": self.meal.repeat_days,
-            "device_id": self.meal.device_id,
-            "enabled": self.meal.enabled,
-        }
-
-
 class PhilipsPetsSeriesInvitesSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Philips Pets Series Invites Sensor."""
 


### PR DESCRIPTION
Reported in #22: after upgrading, three unavailable "Meal" entities remain on the device page.

Per-meal sensors stopped being created before 1.0.0, but upgrades from older versions still carry their registry rows, so they linger as unavailable entities with nothing to indicate they are obsolete. Scheduled meals are exposed through the meal calendar instead.

- Remove those rows on setup.
- Delete the sensor class as well, so it cannot start producing them again. It was unreachable, and its device info disagreed with every other entity's.

Verified on a real install with the leftover rows seeded into the registry: the three obsolete entities go, the meal calendar is untouched, and no entity is left unavailable.