### PR TITLE
1.0.3 — show when the next meal is, instead of a calendar reading "off"

### DIFF
--- a/custom_components/philips_pet_series/calendar.py
+++ b/custom_components/philips_pet_series/calendar.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import List, override
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
@@ -12,6 +12,7 @@ import homeassistant.util.dt as dt_util
 
 from . import DOMAIN, PhilipsPetsSeriesDataUpdateCoordinator
 from .entity import iter_home_devices
+from .meals import occurrences as meal_occurrences
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,7 +43,9 @@ class PhilipsPetsSeriesCalendar(CalendarEntity):
         self.client = client
         self.home = home
         self.device = device
-        self._attr_name = f"{device.name} Meals"
+        # "Meal schedule" rather than "Meals": a calendar only reads "on" while a
+        # meal is being served, and "Meals: Off" looks like feeding is disabled.
+        self._attr_name = "Meal schedule"
         self._attr_unique_id = f"{device.id}_meal_calendar"
         self._attr_timezone = str(self.coordinator.hass.config.time_zone)
         self._events: List[CalendarEvent] = []
@@ -72,66 +75,20 @@ class PhilipsPetsSeriesCalendar(CalendarEntity):
         self, start_date: datetime, end_date: datetime
     ) -> List[CalendarEvent]:
         """Expand this device's enabled meals into events across a date range."""
-        events: List[CalendarEvent] = []
-        meals = self.coordinator.data.get("meals", [])
-
-        for meal in meals:
-            if not meal.enabled:
-                _LOGGER.debug("Skipping disabled meal: %s", meal.name)
-                continue  # Skip disabled meals
-
-            # Check if the meal is associated with this device
-            if meal.device_id != self.device.id:
-                _LOGGER.debug("Skipping meal '%s' for device %s", meal.name, meal.device_id)
-                continue
-
-            # Parse feed_time (e.g., '07:00' or '07:00Z')
-            try:
-                # Try parsing with 'Z' suffix first, then without
-                if meal.feed_time.endswith('Z'):
-                    feed_time_naive = datetime.strptime(meal.feed_time, "%H:%MZ").time()
-                    feed_time_is_utc = True
-                else:
-                    feed_time_naive = datetime.strptime(meal.feed_time, "%H:%M").time()
-                    feed_time_is_utc = False
-            except ValueError as e:
-                _LOGGER.error("Invalid feed_time format for meal '%s': time data '%s' does not match expected format (HH:MM or HH:MMZ)", meal.name, meal.feed_time)
-                continue
-
-            # Map repeat_days (1=Monday, 7=Sunday) to Python's weekday (0=Monday, 6=Sunday)
-            repeat_days = [day - 1 for day in meal.repeat_days if 1 <= day <= 7]
-            _LOGGER.debug("Meal '%s' repeat_days: %s", meal.name, repeat_days)
-
-            # Iterate through each day in the range and create events for matching repeat_days
-            current_date = start_date.date()
-            while current_date <= end_date.date():
-                current_weekday = current_date.weekday()
-                if current_weekday in repeat_days:
-                    event_start = datetime.combine(current_date, feed_time_naive)
-                    event_end = event_start + timedelta(minutes=10)
-
-                    # A trailing 'Z' means the API already reported UTC, so
-                    # attach UTC rather than reinterpreting it as local time.
-                    if feed_time_is_utc:
-                        event_start_utc = event_start.replace(tzinfo=timezone.utc)
-                        event_end_utc = event_end.replace(tzinfo=timezone.utc)
-                    else:
-                        event_start_utc = dt_util.as_utc(event_start)
-                        event_end_utc = dt_util.as_utc(event_end)
-
-                    event = CalendarEvent(
-                        summary=f"{meal.name} (Portion: {meal.portion_amount})",
-                        start=event_start_utc,
-                        end=event_end_utc,
-                        description=f"Feed {meal.portion_amount} portions at {meal.feed_time}",
-                        location=self.home.name,
-                    )
-                    events.append(event)
-                    _LOGGER.debug("Added event: %s, %s - %s", event.summary, event.start, event.end)
-                current_date += timedelta(days=1)
-
-        events.sort(key=lambda event: event.start)
-        return events
+        return [
+            CalendarEvent(
+                summary=f"{occurrence.name} (Portion: {occurrence.portions})",
+                start=occurrence.start,
+                end=occurrence.end,
+                description=(
+                    f"Feed {occurrence.portions} portions at {occurrence.feed_time}"
+                ),
+                location=self.home.name,
+            )
+            for occurrence in meal_occurrences(
+                self.coordinator, self.device.id, start_date, end_date
+            )
+        ]
 
     @property
     def event(self) -> CalendarEvent | None:

--- a/custom_components/philips_pet_series/manifest.json
+++ b/custom_components/philips_pet_series/manifest.json
@@ -13,5 +13,5 @@
     "petsseries==1.0.0",
     "tuya-mobile>=1.0.0"
   ],
-  "version": "1.0.2"
+  "version": "1.0.3"
 }

--- a/custom_components/philips_pet_series/meals.py
+++ b/custom_components/philips_pet_series/meals.py
@@ -1,0 +1,114 @@
+"""Expanding a feeder's meal schedule into concrete occurrences.
+
+Philips describes meals as a time plus the weekdays they repeat on, so turning
+that into actual datetimes is shared by the meal calendar and the "next meal"
+sensor.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import logging
+
+from homeassistant.util import dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+# How long a feeding is treated as "happening" — only used to give calendar
+# entries a visible duration.
+MEAL_DURATION = timedelta(minutes=10)
+
+
+@dataclass(frozen=True)
+class MealOccurrence:
+    """A single scheduled feeding at a concrete moment."""
+
+    start: datetime
+    end: datetime
+    name: str
+    portions: object
+    feed_time: str
+
+
+def device_meals(coordinator, device_id) -> list:
+    """Return the enabled meals belonging to one device."""
+    meals = []
+    for meal in coordinator.data.get("meals", []):
+        if not getattr(meal, "enabled", False):
+            continue
+        if str(getattr(meal, "device_id", "")) != str(device_id):
+            continue
+        meals.append(meal)
+    return meals
+
+
+def _parse_feed_time(meal):
+    """Return (time, is_utc) for a meal's feed time, or None if unparseable.
+
+    A trailing "Z" means the API already reported UTC; without it the time is
+    local to the account.
+    """
+    feed_time = getattr(meal, "feed_time", "") or ""
+    try:
+        if feed_time.endswith("Z"):
+            return datetime.strptime(feed_time, "%H:%MZ").time(), True
+        return datetime.strptime(feed_time, "%H:%M").time(), False
+    except ValueError:
+        _LOGGER.error(
+            "Invalid feed_time for meal '%s': %r does not match HH:MM or HH:MMZ",
+            getattr(meal, "name", "?"),
+            feed_time,
+        )
+        return None
+
+
+def occurrences(coordinator, device_id, start: datetime, end: datetime) -> list[MealOccurrence]:
+    """Expand a device's meals into every occurrence between start and end."""
+    result: list[MealOccurrence] = []
+    for meal in device_meals(coordinator, device_id):
+        parsed = _parse_feed_time(meal)
+        if parsed is None:
+            continue
+        feed_time, is_utc = parsed
+        # Philips numbers weekdays 1=Monday..7=Sunday; Python uses 0=Monday.
+        repeat_days = {
+            day - 1 for day in getattr(meal, "repeat_days", []) or [] if 1 <= day <= 7
+        }
+        if not repeat_days:
+            continue
+        current = start.date()
+        # Step back a day so an occurrence that started just before the window
+        # but is still running is not missed.
+        current -= timedelta(days=1)
+        while current <= end.date():
+            if current.weekday() in repeat_days:
+                naive = datetime.combine(current, feed_time)
+                if is_utc:
+                    begin = naive.replace(tzinfo=timezone.utc)
+                else:
+                    begin = dt_util.as_utc(naive)
+                finish = begin + MEAL_DURATION
+                if finish >= start and begin <= end:
+                    result.append(
+                        MealOccurrence(
+                            start=begin,
+                            end=finish,
+                            name=getattr(meal, "name", "Meal"),
+                            portions=getattr(meal, "portion_amount", None),
+                            feed_time=getattr(meal, "feed_time", ""),
+                        )
+                    )
+            current += timedelta(days=1)
+    result.sort(key=lambda occurrence: occurrence.start)
+    return result
+
+
+def next_occurrence(coordinator, device_id, now: datetime | None = None):
+    """Return the next meal that has not finished yet, if any."""
+    now = now or dt_util.now()
+    upcoming = occurrences(coordinator, device_id, now, now + timedelta(days=8))
+    for occurrence in upcoming:
+        if occurrence.end >= now:
+            return occurrence
+    return None

--- a/custom_components/philips_pet_series/sensor.py
+++ b/custom_components/philips_pet_series/sensor.py
@@ -23,6 +23,7 @@ from . import DOMAIN, PhilipsPetsSeriesDataUpdateCoordinator
 from .const import REMOVED_DP_SENSORS  # noqa: F401  (documented alongside _READ_ONLY_TUYA_DPS)
 from .datapoints import datapoints
 from .entity import PhilipsPetsSeriesEntity, iter_home_devices
+from .meals import device_meals, next_occurrence as next_meal
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -104,6 +105,7 @@ async def async_setup_entry(
         )
         sensors.append(PhilipsPetsSeriesCameraOrientationSensor(coordinator, home, device))
         sensors.append(PhilipsPetsSeriesMotionSnapshotSensor(coordinator, home, device))
+        sensors.append(PhilipsPetsSeriesNextMealSensor(coordinator, home, device))
         for event_type_str in event_types_str:
             sensors.append(
                 PhilipsPetsSeriesEventSensor(coordinator, home, device, event_type_str)
@@ -370,6 +372,43 @@ class PhilipsPetsSeriesMotionSnapshotSensor(PhilipsPetsSeriesEntity, SensorEntit
             "alarm": metadata.get("alarm"),
             "timestamp": metadata.get("time"),
         }
+
+
+class PhilipsPetsSeriesNextMealSensor(PhilipsPetsSeriesEntity, SensorEntity):
+    """When this feeder next serves a scheduled meal.
+
+    The meal calendar is the full schedule, but a calendar only reads "on" while
+    a meal is actually being served, so at a glance it looks like nothing is
+    scheduled.  This sensor always shows the next feeding time instead.
+    """
+
+    def __init__(self, coordinator, home, device) -> None:
+        super().__init__(coordinator, device, home)
+        self._attr_unique_id = f"{device.id}_next_meal"
+        self._attr_name = "Next meal"
+        self._attr_device_class = SensorDeviceClass.TIMESTAMP
+        self._attr_icon = "mdi:calendar-clock"
+
+    @property
+    def native_value(self):
+        occurrence = next_meal(self.coordinator, self._device.id)
+        return occurrence.start if occurrence else None
+
+    @property
+    def extra_state_attributes(self):
+        """Describe the next meal and how much is scheduled overall."""
+        scheduled = device_meals(self.coordinator, self._device.id)
+        attributes = {
+            "scheduled_meals": len(scheduled),
+            "feeding_times": sorted(
+                meal.feed_time for meal in scheduled if getattr(meal, "feed_time", None)
+            ),
+        }
+        occurrence = next_meal(self.coordinator, self._device.id)
+        if occurrence is not None:
+            attributes["meal_name"] = occurrence.name
+            attributes["portions"] = occurrence.portions
+        return attributes
 
 
 class PhilipsPetsSeriesEventSensor(PhilipsPetsSeriesEntity, RestoreSensor):


### PR DESCRIPTION
A calendar entity only reads `on` while an event is actually in progress, so the meal schedule showed `off` for all but ten minutes of every feeding cycle. That reads as "feeding is disabled", and it already caused confusion in #22, where scheduled meals were reported as "no longer provided" while they were present the whole time.

- New **Next meal** timestamp sensor: always populated, shows as a countdown, and carries `scheduled_meals` and `feeding_times` attributes so the full schedule is visible at a glance.
- Calendar renamed to **Meal schedule**, so `off` clearly describes a schedule rather than switched-off feeding.
- Meal expansion moved into one shared helper used by both, which also fixes the calendar skipping a meal that had already started.

Verified on a real feeder: `Next meal` reads the correct next feeding, `scheduled_meals = 7`, `feeding_times` lists all seven, and the calendar shows `on` while a meal is being served and `off` otherwise.