### PR TITLE
1.0.4 — "Next meal" no longer shows a past time, plus a scheduled-feeding sensor

### DIFF
--- a/custom_components/philips_pet_series/binary_sensor.py
+++ b/custom_components/philips_pet_series/binary_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.util import dt as dt_util
 
 from . import DOMAIN, PhilipsPetsSeriesDataUpdateCoordinator
 from .entity import PhilipsPetsSeriesEntity, iter_home_devices
+from .meals import device_meals
 
 _CONDITIONS = {
     "food_level_low": ("Food level low", BinarySensorDeviceClass.PROBLEM),
@@ -50,11 +51,46 @@ async def async_setup_entry(
     coordinator: PhilipsPetsSeriesDataUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ]["coordinator"]
-    async_add_entities(
+    entities = [
         PhilipsPetsSeriesConditionSensor(coordinator, home, device, event_type)
         for home, device in iter_home_devices(coordinator)
         for event_type in _CONDITIONS
-    )
+    ]
+    entities += [
+        PhilipsPetsSeriesScheduledFeedingSensor(coordinator, home, device)
+        for home, device in iter_home_devices(coordinator)
+    ]
+    async_add_entities(entities)
+
+
+class PhilipsPetsSeriesScheduledFeedingSensor(PhilipsPetsSeriesEntity, BinarySensorEntity):
+    """Whether this feeder has any scheduled meal switched on.
+
+    The meal calendar can only report "on" while a meal is actually being
+    served, which reads as though feeding were switched off for the rest of the
+    day.  This answers the simpler question: is the feeder set to feed on a
+    schedule at all?
+    """
+
+    def __init__(self, coordinator, home, device) -> None:
+        super().__init__(coordinator, device, home)
+        self._attr_unique_id = f"{device.id}_scheduled_feeding"
+        self._attr_name = "Scheduled feeding"
+        self._attr_icon = "mdi:calendar-check"
+
+    @property
+    def is_on(self) -> bool:
+        return bool(device_meals(self.coordinator, self._device.id))
+
+    @property
+    def extra_state_attributes(self):
+        meals = device_meals(self.coordinator, self._device.id)
+        return {
+            "scheduled_meals": len(meals),
+            "feeding_times": sorted(
+                meal.feed_time for meal in meals if getattr(meal, "feed_time", None)
+            ),
+        }
 
 
 class PhilipsPetsSeriesConditionSensor(PhilipsPetsSeriesEntity, BinarySensorEntity):

--- a/custom_components/philips_pet_series/manifest.json
+++ b/custom_components/philips_pet_series/manifest.json
@@ -13,5 +13,5 @@
     "petsseries==1.0.0",
     "tuya-mobile>=1.0.0"
   ],
-  "version": "1.0.3"
+  "version": "1.0.4"
 }

--- a/custom_components/philips_pet_series/meals.py
+++ b/custom_components/philips_pet_series/meals.py
@@ -105,10 +105,15 @@ def occurrences(coordinator, device_id, start: datetime, end: datetime) -> list[
 
 
 def next_occurrence(coordinator, device_id, now: datetime | None = None):
-    """Return the next meal that has not finished yet, if any."""
+    """Return the next meal that has not started yet, if any.
+
+    Strictly upcoming: a meal currently being served is in the past as far as
+    "next meal" is concerned, and reporting it would render as a time that has
+    already passed.  The calendar, which does need the in-progress one, uses
+    ``occurrences`` directly.
+    """
     now = now or dt_util.now()
-    upcoming = occurrences(coordinator, device_id, now, now + timedelta(days=8))
-    for occurrence in upcoming:
-        if occurrence.end >= now:
+    for occurrence in occurrences(coordinator, device_id, now, now + timedelta(days=8)):
+        if occurrence.start > now:
             return occurrence
     return None


### PR DESCRIPTION
Follow-up to 1.0.3, from feedback that the meal schedule showed `On` while "Next meal" read *7 minutes ago*.

**"Next meal" showed a past time.** It returned any meal that had not yet finished, so during the ten minutes a meal is being served it reported that meal. It now only considers meals that have not started.

**New `Scheduled feeding` binary sensor** — on whenever any meal is enabled, with `scheduled_meals` and `feeding_times` attributes.

A calendar entity can only be `on` while an event is actually in progress, so the meal schedule reads `off` for all but ten minutes of each feeding cycle, which looks like feeding is disabled. Overriding the calendar's state would misreport to calendar triggers and any card consuming its events, so this answers the on/off question with a purpose-built entity instead.

Verified on a real feeder: next meal now reads 169 minutes ahead rather than in the past, scheduled feeding is `on` with all seven feeding times, and the calendar is `off` outside a meal and `on` during one.