### PR TITLE
1.1.0 — find the feeder on the local network from its own broadcast

### DIFF
--- a/custom_components/philips_pet_series/__init__.py
+++ b/custom_components/philips_pet_series/__init__.py
@@ -48,6 +48,7 @@ from .const import (
     REMOVED_DP_SENSORS,
 )
 from .bridge import PhilipsCameraBridgeManager
+from .lanbeacon import BeaconListener
 from .datapoints import datapoints
 
 PLATFORMS = [
@@ -410,6 +411,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ) from err
     hass.data[DOMAIN][entry.entry_id]["bridge"] = bridge
 
+    # Passive LAN beacon watch: gives each feeder's current address and a
+    # cloud-independent presence signal. Optional -- a container on Docker's
+    # bridge network never sees the broadcast.
+    beacons = BeaconListener()
+    await beacons.async_start()
+    hass.data[DOMAIN][entry.entry_id]["beacons"] = beacons
+
     # Camera streaming mode is read at bridge start, so apply option changes by
     # reloading the entry.
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
@@ -635,6 +643,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         bridge = entry_data.get("bridge")
         if bridge is not None:
             await bridge.async_stop()
+        beacons = entry_data.get("beacons")
+        if beacons is not None:
+            beacons.async_stop()
         client = entry_data["client"]
         await client.close()
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/custom_components/philips_pet_series/binary_sensor.py
+++ b/custom_components/philips_pet_series/binary_sensor.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
@@ -60,7 +61,46 @@ async def async_setup_entry(
         PhilipsPetsSeriesScheduledFeedingSensor(coordinator, home, device)
         for home, device in iter_home_devices(coordinator)
     ]
+    beacons = hass.data[DOMAIN][config_entry.entry_id].get("beacons")
+    if beacons is not None:
+        entities += [
+            PhilipsPetsSeriesOnLanSensor(coordinator, home, device, beacons)
+            for home, device in iter_home_devices(coordinator)
+        ]
     async_add_entities(entities)
+
+
+class PhilipsPetsSeriesOnLanSensor(PhilipsPetsSeriesEntity, BinarySensorEntity):
+    """Whether the feeder is announcing itself on the local network.
+
+    Independent of the cloud, and unlike the connectivity sensor it does not
+    depend on Philips having recorded any online/offline events. Reports unknown
+    rather than "away" where the broadcast cannot reach Home Assistant at all,
+    which is the case for a container on Docker's bridge network.
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+
+    def __init__(self, coordinator, home, device, beacons) -> None:
+        super().__init__(coordinator, device, home)
+        self._beacons = beacons
+        self._attr_unique_id = f"{device.id}_on_lan"
+        self._attr_name = "On local network"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def available(self) -> bool:
+        # Only claim to know once we have actually heard a beacon from *some*
+        # device; otherwise we cannot distinguish "away" from "cannot listen".
+        return (
+            super().available
+            and self._beacons.listening
+            and self._beacons.any_seen
+        )
+
+    @property
+    def is_on(self) -> bool:
+        return self._beacons.seen(self.coordinator.tuya_device_id(self._device)) is not None
 
 
 class PhilipsPetsSeriesScheduledFeedingSensor(PhilipsPetsSeriesEntity, BinarySensorEntity):

--- a/custom_components/philips_pet_series/lanbeacon.py
+++ b/custom_components/philips_pet_series/lanbeacon.py
@@ -1,0 +1,162 @@
+"""Locate feeders on the local network from their Tuya broadcast.
+
+Tuya devices announce themselves on UDP 6667 every few seconds. The payload is
+AES-ECB encrypted with a key published in Tuya's own SDK, and carries the
+device's ``gwId`` -- the same identifier the cloud API calls ``vendorId`` -- so a
+beacon can be matched to a configured device exactly, with no guesswork about
+MAC prefixes or hostnames.
+
+This is passive: nothing is ever sent to the device. It provides the device's
+current LAN address (which survives DHCP changes) and a genuine "is it on the
+network" signal, independent of the cloud.
+
+Important: a Home Assistant container on Docker's default bridge network does
+not receive LAN broadcasts, so no beacon will ever arrive there. Absence of a
+beacon therefore means "no information", never "the device is offline" --
+callers must treat :meth:`BeaconListener.seen` returning ``None`` as unknown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import hashlib
+import json
+import logging
+import time
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+_LOGGER = logging.getLogger(__name__)
+
+BEACON_PORT = 6667
+# Published in Tuya's SDK for the discovery broadcast; not device-specific.
+_BROADCAST_KEY = hashlib.md5(b"yGAdlopoPVldABfn").digest()
+_HEADER = 20
+_TRAILER = 8
+
+# Beacons arrive roughly every 5s; allow generous slack for a missed few.
+STALE_AFTER = 60.0
+
+
+@dataclass
+class Beacon:
+    """The last announcement seen from one device."""
+
+    ip: str
+    at: float
+    protocol: str | None = None
+
+    @property
+    def age(self) -> float:
+        return time.monotonic() - self.at
+
+    @property
+    def fresh(self) -> bool:
+        return self.age <= STALE_AFTER
+
+
+def _decrypt(packet: bytes) -> dict | None:
+    """Return the beacon's JSON payload, or None if it is not one of ours."""
+    if len(packet) <= _HEADER + _TRAILER:
+        return None
+    body = packet[_HEADER:-_TRAILER]
+    if len(body) % 16:
+        return None
+    try:
+        decryptor = Cipher(algorithms.AES(_BROADCAST_KEY), modes.ECB()).decryptor()
+        plain = decryptor.update(body) + decryptor.finalize()
+    except Exception:
+        return None
+    if plain and plain[-1] <= 16:
+        plain = plain[: -plain[-1]]
+    try:
+        payload = json.loads(plain.decode("utf-8", "replace"))
+    except ValueError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+class _Protocol(asyncio.DatagramProtocol):
+    def __init__(self, listener: BeaconListener) -> None:
+        self._listener = listener
+
+    def datagram_received(self, data: bytes, addr: tuple) -> None:
+        payload = _decrypt(data)
+        if not payload:
+            return
+        device_id = payload.get("gwId") or payload.get("devId")
+        if not device_id:
+            return
+        self._listener._record(
+            str(device_id),
+            str(payload.get("ip") or addr[0]),
+            payload.get("version"),
+        )
+
+    def error_received(self, exc: Exception) -> None:  # pragma: no cover
+        _LOGGER.debug("Beacon socket error: %s", exc)
+
+
+class BeaconListener:
+    """Passively track which feeders are announcing themselves on the LAN."""
+
+    def __init__(self) -> None:
+        self._beacons: dict[str, Beacon] = {}
+        self._transport: asyncio.BaseTransport | None = None
+
+    @property
+    def listening(self) -> bool:
+        """Whether the socket is open. False means we know nothing at all."""
+        return self._transport is not None
+
+    def _record(self, device_id: str, ip: str, protocol) -> None:
+        previous = self._beacons.get(device_id)
+        if previous is None or previous.ip != ip:
+            _LOGGER.debug("Feeder %s announced itself at %s", device_id, ip)
+        self._beacons[device_id] = Beacon(
+            ip=ip,
+            at=time.monotonic(),
+            protocol=str(protocol) if protocol is not None else None,
+        )
+
+    @property
+    def any_seen(self) -> bool:
+        """Whether any device has ever announced itself.
+
+        Distinguishes "this feeder is away" from "broadcasts never reach us".
+        """
+        return bool(self._beacons)
+
+    def seen(self, device_id: str | None) -> Beacon | None:
+        """Return the last fresh beacon for a device, else None (= unknown)."""
+        if not device_id:
+            return None
+        beacon = self._beacons.get(str(device_id))
+        return beacon if beacon is not None and beacon.fresh else None
+
+    async def async_start(self) -> None:
+        """Open the listening socket, tolerating hosts that cannot listen."""
+        if self._transport is not None:
+            return
+        loop = asyncio.get_running_loop()
+        try:
+            transport, _ = await loop.create_datagram_endpoint(
+                lambda: _Protocol(self),
+                local_addr=("0.0.0.0", BEACON_PORT),
+                reuse_port=True,
+                allow_broadcast=True,
+            )
+        except Exception as err:
+            # Another process may hold the port, or the platform may refuse it.
+            # This is optional enrichment, so carry on without it.
+            _LOGGER.debug("Not listening for feeder beacons: %s", err)
+            return
+        self._transport = transport
+        _LOGGER.debug("Listening for feeder beacons on udp/%s", BEACON_PORT)
+
+    def async_stop(self) -> None:
+        if self._transport is not None:
+            self._transport.close()
+            self._transport = None
+        self._beacons.clear()

--- a/custom_components/philips_pet_series/manifest.json
+++ b/custom_components/philips_pet_series/manifest.json
@@ -13,5 +13,5 @@
     "petsseries==1.0.0",
     "tuya-mobile>=1.0.0"
   ],
-  "version": "1.0.4"
+  "version": "1.1.0"
 }

--- a/custom_components/philips_pet_series/sensor.py
+++ b/custom_components/philips_pet_series/sensor.py
@@ -78,6 +78,7 @@ async def async_setup_entry(
     coordinator: PhilipsPetsSeriesDataUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ]["coordinator"]
+    beacons = hass.data[DOMAIN][config_entry.entry_id].get("beacons")
 
     event_types = coordinator.data.get("event_types", [])
 
@@ -106,6 +107,9 @@ async def async_setup_entry(
         sensors.append(PhilipsPetsSeriesCameraOrientationSensor(coordinator, home, device))
         sensors.append(PhilipsPetsSeriesMotionSnapshotSensor(coordinator, home, device))
         sensors.append(PhilipsPetsSeriesNextMealSensor(coordinator, home, device))
+        sensors.append(
+            PhilipsPetsSeriesLanAddressSensor(coordinator, home, device, beacons)
+        )
         for event_type_str in event_types_str:
             sensors.append(
                 PhilipsPetsSeriesEventSensor(coordinator, home, device, event_type_str)
@@ -372,6 +376,46 @@ class PhilipsPetsSeriesMotionSnapshotSensor(PhilipsPetsSeriesEntity, SensorEntit
             "alarm": metadata.get("alarm"),
             "timestamp": metadata.get("time"),
         }
+
+
+class PhilipsPetsSeriesLanAddressSensor(PhilipsPetsSeriesEntity, SensorEntity):
+    """The feeder's current address on the local network.
+
+    Learned passively from the device's own broadcast, so it follows DHCP
+    changes without anything being configured.
+    """
+
+    def __init__(self, coordinator, home, device, beacons) -> None:
+        super().__init__(coordinator, device, home)
+        self._beacons = beacons
+        self._attr_unique_id = f"{device.id}_lan_address"
+        self._attr_name = "LAN address"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_icon = "mdi:ip-network"
+        # Off by default: interesting for diagnosis, noise on a dashboard.
+        self._attr_entity_registry_enabled_default = False
+
+    def _beacon(self):
+        if self._beacons is None:
+            return None
+        return self._beacons.seen(self.coordinator.tuya_device_id(self._device))
+
+    @property
+    def available(self) -> bool:
+        # No beacon means "we cannot know", not "no address".
+        return super().available and self._beacon() is not None
+
+    @property
+    def native_value(self):
+        beacon = self._beacon()
+        return beacon.ip if beacon else None
+
+    @property
+    def extra_state_attributes(self):
+        beacon = self._beacon()
+        if beacon is None:
+            return {}
+        return {"protocol_version": beacon.protocol, "last_seen_seconds_ago": round(beacon.age)}
 
 
 class PhilipsPetsSeriesNextMealSensor(PhilipsPetsSeriesEntity, SensorEntity):


### PR DESCRIPTION
Tuya devices announce themselves on UDP 6667 every few seconds, encrypted with a key published in Tuya's SDK. The payload carries `gwId` — the same identifier the cloud calls `vendorId` — so a broadcast matches a configured feeder **exactly**, with no MAC-prefix or hostname guessing.

Adds a passive listener (nothing is ever sent to the device) plus two diagnostic entities:

- **LAN address** — the feeder's current address, following DHCP changes with nothing configured. Disabled by default.
- **On local network** — presence straight from the device, independent of the cloud. Unlike the connectivity sensor it does not depend on Philips having recorded online/offline events; the reporters in #22 had none, which is exactly why that sensor read unknown for them.

### Degradation is the important part

A Home Assistant container on Docker's default bridge network **never receives LAN broadcasts**. Both entities therefore report `unavailable` there rather than inventing an answer — absence of a broadcast is "no information", never "the feeder is away".