### PR TITLE
1.2.0 — make the camera stream address discoverable, and document recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ No RTSP URL, Tuya device ID, IP address, local key, external signer, qemu
 process, add-on, or system service is required. The camera entity also serves
 the latest cloud motion snapshot when Home Assistant requests a still image.
 
+By default the camera is connected to only while something is watching, because
+the feeder allows just a couple of simultaneous connections and holding one open
+can disconnect the Philips app. Choose **Camera streaming → Always on** in the
+integration's options if something outside Home Assistant needs the stream
+continuously.
+
+### Recording in an NVR
+
+Frigate, go2rtc and similar recorders can use the camera. See
+**[docs/nvr.md](docs/nvr.md)** for working configuration, the settings you need
+to change first, and measured figures for which options are worth the CPU.
+
 ## Contributing
 
 Contributions are welcome — please open an issue or pull request on the

--- a/custom_components/philips_pet_series/bridge.py
+++ b/custom_components/philips_pet_series/bridge.py
@@ -11,6 +11,7 @@ import asyncio
 from dataclasses import dataclass, field
 from datetime import timedelta
 import hashlib
+import ipaddress
 import logging
 import os
 from pathlib import Path
@@ -27,7 +28,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from tuya_mobile import mqtt_client_id, mqtt_credentials
 
-from .const import CONF_CAMERA_MODE
+from homeassistant.helpers.network import get_url
+
+from .const import CONF_CAMERA_MODE, CONF_IDLE_TIMEOUT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,6 +53,8 @@ CAMERA_MODES = (CAMERA_MODE_ON_DEMAND, CAMERA_MODE_ALWAYS, CAMERA_MODE_DISABLED)
 # stream component re-requests the source periodically while a viewer is
 # attached, so this only has to outlast the gap between those requests.
 IDLE_TIMEOUT = timedelta(minutes=5)
+IDLE_TIMEOUT_MIN_MINUTES = 1
+IDLE_TIMEOUT_MAX_MINUTES = 60
 _IDLE_CHECK_INTERVAL = 30
 
 # A bridge can lose its camera session without exiting, which the exit-driven
@@ -94,6 +99,22 @@ _BRIDGE_ARCH_MAP = {
     "armv6l": "arm",
     "arm": "arm",
 }
+
+
+def _is_usable_host(host: str) -> bool:
+    """Whether an address is plausibly reachable from another machine.
+
+    Loopback is never reachable elsewhere. Docker's default bridge network sits in
+    172.16.0.0/12, so an address there is very likely the container's own and not
+    the host's.
+    """
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return True  # a hostname; assume the user knows their own DNS
+    if address.is_loopback or address.is_link_local:
+        return False
+    return address not in ipaddress.ip_network("172.16.0.0/12")
 
 
 @dataclass(slots=True)
@@ -153,6 +174,72 @@ class PhilipsCameraBridgeManager:
             CONF_CAMERA_MODE, CAMERA_MODE_ON_DEMAND
         )
         return mode if mode in CAMERA_MODES else CAMERA_MODE_ON_DEMAND
+
+    @property
+    def idle_timeout(self) -> float:
+        """Seconds an on-demand session lingers after the last stream request."""
+        configured = {**self.entry.data, **self.entry.options}.get(CONF_IDLE_TIMEOUT)
+        try:
+            minutes = float(configured)
+        except (TypeError, ValueError):
+            return IDLE_TIMEOUT.total_seconds()
+        minutes = max(IDLE_TIMEOUT_MIN_MINUTES, min(IDLE_TIMEOUT_MAX_MINUTES, minutes))
+        return minutes * 60
+
+    def stream_endpoint(self, device: Any) -> dict[str, Any] | None:
+        """How something *outside* Home Assistant should reach this camera.
+
+        ``stream_url`` is loopback, which is right inside Home Assistant but
+        useless to a separate recorder -- pointing an NVR at 127.0.0.1 is the
+        single most common setup mistake.
+
+        Home Assistant's own address is only trustworthy when it has been
+        configured. Auto-detection returns whatever address the host happens to
+        see, which inside a container is the container's own address and no use
+        to anything else, so say where the value came from rather than presenting
+        a guess as fact.
+        """
+        device_key = str(getattr(device, "id", ""))
+        port = self._ports.get(device_key)
+        if port is None:
+            return None
+        path = f"/philips-pet-{device_key.lower()}"
+
+        host, source = None, "unknown"
+        configured = getattr(self.hass.config, "internal_url", None)
+        if configured:
+            try:
+                host = urlsplit(configured).hostname
+                source = "configured"
+            except ValueError:
+                host = None
+        if not host:
+            try:
+                host = urlsplit(get_url(self.hass, allow_external=False)).hostname
+                source = "detected"
+            except Exception:
+                host = None
+        if not host:
+            return {"port": port, "path": path, "address_source": "unknown", "url": None}
+
+        result = {
+            "url": f"rtsp://{host}:{port}{path}",
+            "port": port,
+            "path": path,
+            "address_source": source,
+        }
+        if source == "detected" and not _is_usable_host(host):
+            result["note"] = (
+                "This address was detected automatically and looks local to Home "
+                "Assistant's own container, so another machine cannot reach it. "
+                "Replace the host with the address you use to open Home Assistant."
+            )
+        return result
+
+    def public_stream_url(self, device: Any) -> str | None:
+        """The externally reachable stream URL, or None if it cannot be built."""
+        endpoint = self.stream_endpoint(device)
+        return endpoint.get("url") if endpoint else None
 
     @property
     def processes(self) -> dict[str, BridgeProcess]:
@@ -230,7 +317,7 @@ class PhilipsCameraBridgeManager:
 
     async def _async_reap_idle(self) -> None:
         """Release on-demand sessions once nothing has asked for the stream."""
-        idle_seconds = IDLE_TIMEOUT.total_seconds()
+        idle_seconds = self.idle_timeout
         while not self._stopping:
             await asyncio.sleep(_IDLE_CHECK_INTERVAL)
             now = time.monotonic()
@@ -464,7 +551,7 @@ class PhilipsCameraBridgeManager:
         # An idle on-demand session that was reaped needs no replacement; it is
         # re-created on the next stream request.
         if self.camera_mode == CAMERA_MODE_ON_DEMAND and (
-            time.monotonic() - bridge.last_requested >= IDLE_TIMEOUT.total_seconds()
+            time.monotonic() - bridge.last_requested >= self.idle_timeout
         ):
             _LOGGER.debug(
                 "Camera bridge for %s stopped while idle (%s); not restarting",

--- a/custom_components/philips_pet_series/config_flow.py
+++ b/custom_components/philips_pet_series/config_flow.py
@@ -15,11 +15,18 @@ from petsseries.auth import AuthError, AuthManager  # type: ignore[import-not-fo
 from homeassistant.helpers import selector  # type: ignore[import-not-found]
 from zoneinfo import available_timezones
 
-from .bridge import CAMERA_MODE_ON_DEMAND, CAMERA_MODES
+from .bridge import (
+    CAMERA_MODE_ON_DEMAND,
+    CAMERA_MODES,
+    IDLE_TIMEOUT,
+    IDLE_TIMEOUT_MAX_MINUTES,
+    IDLE_TIMEOUT_MIN_MINUTES,
+)
 from .const import (
     CONF_ACCESS_TOKEN,
     CONF_CAMERA_MODE,
     CONF_COUNTRY,
+    CONF_IDLE_TIMEOUT,
     CONF_HOME_IDS,
     CONF_ID_TOKEN,
     CONF_LANGUAGE,
@@ -352,6 +359,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         )
         if current not in CAMERA_MODES:
             current = CAMERA_MODE_ON_DEMAND
+        merged = {**self.config_entry.data, **self.config_entry.options}
+        idle_default = merged.get(
+            CONF_IDLE_TIMEOUT, int(IDLE_TIMEOUT.total_seconds() // 60)
+        )
         schema = vol.Schema(
             {
                 vol.Required(
@@ -361,6 +372,17 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         options=list(CAMERA_MODES),
                         translation_key="camera_mode",
                         mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
+                vol.Required(
+                    CONF_IDLE_TIMEOUT, default=idle_default
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=IDLE_TIMEOUT_MIN_MINUTES,
+                        max=IDLE_TIMEOUT_MAX_MINUTES,
+                        step=1,
+                        unit_of_measurement="min",
+                        mode=selector.NumberSelectorMode.BOX,
                     )
                 ),
             }

--- a/custom_components/philips_pet_series/const.py
+++ b/custom_components/philips_pet_series/const.py
@@ -27,6 +27,7 @@ CONF_TIMEZONE = "timezone"
 CONF_LANGUAGE = "language"
 CONF_COUNTRY = "country"
 CONF_CAMERA_MODE = "camera_mode"
+CONF_IDLE_TIMEOUT = "idle_timeout_minutes"
 
 # Datapoints once exposed as sensors that carried no usable meaning.  Verified
 # against two days of recorded history: 203 (a write-only command register) and

--- a/custom_components/philips_pet_series/diagnostics.py
+++ b/custom_components/philips_pet_series/diagnostics.py
@@ -27,6 +27,35 @@ TO_REDACT = {
 }
 
 
+def _frigate_example(cameras: list[dict]) -> list[str] | str:
+    """Recording-only Frigate configuration for the discovered cameras."""
+    if not cameras:
+        return "No camera stream available; set Camera streaming to 'always'."
+    lines = ["go2rtc:", "  streams:"]
+    for index, camera in enumerate(cameras):
+        name = "feeder" if index == 0 else f"feeder_{index + 1}"
+        lines += [f"    {name}:", f'      - "{camera["stream_url"]}"']
+    lines += ["", "cameras:"]
+    for index, camera in enumerate(cameras):
+        name = "feeder" if index == 0 else f"feeder_{index + 1}"
+        lines += [
+            f"  {name}:",
+            "    ffmpeg:",
+            "      input_args: preset-rtsp-restream -analyzeduration 1000000 -probesize 1000000",
+            "      inputs:",
+            f"        - path: rtsp://127.0.0.1:8554/{name}",
+            "          roles:",
+            "            - record",
+            "    detect:",
+            "      enabled: false",
+            "    motion:",
+            "      enabled: true",
+            "    record:",
+            "      enabled: true",
+        ]
+    return lines
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: ConfigEntry
 ) -> dict[str, Any]:
@@ -67,6 +96,27 @@ async def async_get_config_entry_diagnostics(
                 "settings_devices_count": len(coordinator.data.get("settings", {})),
             }
             data["coordinator"]["data_summary"] = coordinator_summary
+
+    bridge = domain_data.get("bridge")
+    if bridge is not None:
+        # A ready-to-paste recorder configuration. The address is the hardest
+        # part to discover, and the loopback form shown inside Home Assistant
+        # does not work from a separate recorder.
+        cameras = []
+        for device in (coordinator.data.get("devices", []) if coordinator else []):
+            endpoint = bridge.stream_endpoint(device)
+            if endpoint and endpoint.get("url"):
+                entry_info = {"name": device.name, "stream_url": endpoint["url"],
+                              "address_source": endpoint.get("address_source")}
+                if endpoint.get("note"):
+                    entry_info["note"] = endpoint["note"]
+                cameras.append(entry_info)
+        data["camera_streaming"] = {
+            "mode": bridge.camera_mode,
+            "cameras": cameras,
+            "frigate_example": _frigate_example(cameras),
+            "documentation": "https://github.com/AboveColin/HA-Philips-Pet-Series/blob/main/docs/nvr.md",
+        }
 
     if client:
         data["client"] = {

--- a/custom_components/philips_pet_series/manifest.json
+++ b/custom_components/philips_pet_series/manifest.json
@@ -13,5 +13,5 @@
     "petsseries==1.0.0",
     "tuya-mobile>=1.0.0"
   ],
-  "version": "1.1.0"
+  "version": "1.2.0"
 }

--- a/custom_components/philips_pet_series/sensor.py
+++ b/custom_components/philips_pet_series/sensor.py
@@ -79,6 +79,7 @@ async def async_setup_entry(
         config_entry.entry_id
     ]["coordinator"]
     beacons = hass.data[DOMAIN][config_entry.entry_id].get("beacons")
+    bridge = hass.data[DOMAIN][config_entry.entry_id].get("bridge")
 
     event_types = coordinator.data.get("event_types", [])
 
@@ -110,6 +111,10 @@ async def async_setup_entry(
         sensors.append(
             PhilipsPetsSeriesLanAddressSensor(coordinator, home, device, beacons)
         )
+        if bridge is not None:
+            sensors.append(
+                PhilipsPetsSeriesStreamUrlSensor(coordinator, home, device, bridge)
+            )
         for event_type_str in event_types_str:
             sensors.append(
                 PhilipsPetsSeriesEventSensor(coordinator, home, device, event_type_str)
@@ -375,6 +380,42 @@ class PhilipsPetsSeriesMotionSnapshotSensor(PhilipsPetsSeriesEntity, SensorEntit
             "media_type": metadata.get("type"),
             "alarm": metadata.get("alarm"),
             "timestamp": metadata.get("time"),
+        }
+
+
+class PhilipsPetsSeriesStreamUrlSensor(PhilipsPetsSeriesEntity, SensorEntity):
+    """The camera's RTSP address, as a recorder outside Home Assistant needs it.
+
+    Without this the address can only be found in debug logs, and the loopback
+    form shown inside Home Assistant does not work from anywhere else -- which
+    is the usual reason an NVR cannot connect.
+    """
+
+    def __init__(self, coordinator, home, device, bridge) -> None:
+        super().__init__(coordinator, device, home)
+        self._bridge = bridge
+        self._attr_unique_id = f"{device.id}_stream_url"
+        self._attr_name = "Camera stream address"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_icon = "mdi:link-variant"
+        self._attr_entity_registry_enabled_default = False
+
+    @property
+    def available(self) -> bool:
+        return super().available and self.native_value is not None
+
+    @property
+    def native_value(self):
+        return self._bridge.public_stream_url(self._device)
+
+    @property
+    def extra_state_attributes(self):
+        """Say where the address came from, and warn if it was only guessed."""
+        endpoint = self._bridge.stream_endpoint(self._device) or {}
+        return {
+            key: endpoint[key]
+            for key in ("port", "path", "address_source", "note")
+            if key in endpoint
         }
 
 

--- a/custom_components/philips_pet_series/translations/en.json
+++ b/custom_components/philips_pet_series/translations/en.json
@@ -111,10 +111,12 @@
       "init": {
         "title": "Philips Pets Series options",
         "data": {
-          "camera_mode": "Camera streaming"
+          "camera_mode": "Camera streaming",
+          "idle_timeout_minutes": "Disconnect from the camera after"
         },
         "data_description": {
-          "camera_mode": "The feeder allows only a few simultaneous camera connections, and opening one can disconnect the Philips app. 'Only while watching' connects on demand (recommended). 'Always on' keeps the stream up permanently, which external recorders need. 'Off' never connects to the camera."
+          "camera_mode": "The feeder allows only a few simultaneous camera connections, and opening one can disconnect the Philips app. 'Only while watching' connects on demand (recommended). 'Always on' keeps the stream up permanently, which external recorders need. 'Off' never connects to the camera.",
+          "idle_timeout_minutes": "Only used when camera streaming is set to 'Only while watching'. When you close the camera view, Home Assistant waits this long before letting go of the camera. A longer wait makes opening the camera again instant; a shorter one hands the camera back to the Philips app sooner. Five minutes suits most people."
         }
       }
     }

--- a/docs/nvr.md
+++ b/docs/nvr.md
@@ -1,0 +1,242 @@
+# Recording the feeder camera (Frigate, go2rtc, Scrypted)
+
+Your feeder's camera can be recorded by a video recorder such as Frigate, the
+same way an ordinary security camera would be. The integration does the hard
+part: it turns the feeder's camera into a normal camera stream that any recorder
+can read.
+
+This page uses Frigate as the example, because it is the most common. The same
+ideas apply to other recorders.
+
+---
+
+## Step 1 — two settings to change first
+
+### In Home Assistant: set camera streaming to "Always on"
+
+Go to **Settings → Devices & services → Philips Pet Series → Configure** and set
+**Camera streaming** to **Always on**.
+
+Normally the integration only connects to the camera while you are actually
+looking at it, and disconnects afterwards. That is on purpose: the feeder only
+allows a couple of connections at the same time, and keeping one open can knock
+the Philips phone app offline. A recorder needs the camera available all day, so
+it needs this setting.
+
+### In Frigate: turn on "Preload camera stream"
+
+In Frigate, open the camera's settings and enable **Preload camera stream**.
+
+Without it, Frigate only asks for the picture when it needs it, and then has to
+wait for the connection to the camera to be built up from scratch — which often
+takes longer than Frigate is willing to wait, so it gives up and tries again.
+Preloading keeps the connection ready, so there is never a wait.
+
+---
+
+## Step 2 — find your camera's address
+
+The address looks like this:
+
+```
+rtsp://<your-home-assistant-ip>:8560/philips-pet-<device-id>
+```
+
+You need to fill in two things:
+
+- **your Home Assistant IP address** — the address you use to open Home
+  Assistant, without the port
+- **your feeder's device id** — enable the **LAN address** entity on the feeder's
+  device page to see it, or switch on debug logging for
+  `custom_components.philips_pet_series` and look in the log
+
+### An example
+
+Imagine your home network looks like this (these are made-up numbers):
+
+| | Address |
+|---|---|
+| Home Assistant | `192.168.1.10` |
+| Frigate | `192.168.1.20` |
+| The feeder itself | `192.168.1.55` |
+| The feeder's device id | `01ab2cd3ef4gh5ij6kl7mn8op9` |
+
+Then your camera address is:
+
+```
+rtsp://192.168.1.10:8560/philips-pet-01ab2cd3ef4gh5ij6kl7mn8op9
+```
+
+Two things that surprise people:
+
+- **You never use the feeder's own address** (`192.168.1.55`). The camera does not
+  hand out video by itself — everything goes through Home Assistant.
+- **You never use Frigate's address either** (`192.168.1.20`). Frigate does not
+  need to refer to itself.
+
+> ### The mistake almost everyone makes
+>
+> Writing `127.0.0.1:8560` instead of Home Assistant's real address.
+>
+> `127.0.0.1` means "this machine". When Frigate reads it, it looks inside
+> **itself** — but the camera connection lives inside **Home Assistant**, so
+> Frigate finds nothing and reports *connection refused*.
+>
+> This is true even if Frigate runs as a Home Assistant add-on: the add-on is
+> still separate from Home Assistant itself.
+>
+> Confusingly, the `127.0.0.1:8554` further down in the config **is** correct.
+> That one points at a part of Frigate, so "this machine" is right there.
+
+---
+
+## Step 3 — pick one of these two configurations
+
+Both are complete. Copy one into your Frigate configuration and replace
+`<your-home-assistant-ip>` and `<device-id>` with your own values.
+
+### Option A — recording only (recommended)
+
+Choose this if you want the feeder recorded and shown in Frigate, and you are
+happy to watch it in the Frigate app or Home Assistant rather than needing it to
+play in every web browser. It is **by far** the lighter option — see
+[why](#why-these-settings) below.
+
+```yaml
+go2rtc:
+  streams:
+    feeder:
+      - "rtsp://<your-home-assistant-ip>:8560/philips-pet-<device-id>"
+
+cameras:
+  petfeeder:
+    ffmpeg:
+      input_args: preset-rtsp-restream -analyzeduration 1000000 -probesize 1000000
+      inputs:
+        - path: rtsp://127.0.0.1:8554/feeder
+          roles:
+            - record
+    detect:
+      enabled: false
+    motion:
+      enabled: true
+    record:
+      enabled: true
+```
+
+### Option B — recording plus live view in a web browser
+
+Choose this if you want the camera to play in a normal browser tab. The feeder
+sends its video in a format (HEVC) that most browsers cannot play, so it has to
+be converted, and converting uses roughly one processor core the whole time it
+is running.
+
+```yaml
+go2rtc:
+  streams:
+    feeder_source:
+      - "rtsp://<your-home-assistant-ip>:8560/philips-pet-<device-id>"
+    feeder:
+      - "ffmpeg:feeder_source#video=h264#rotate=90#audio=copy"
+
+cameras:
+  petfeeder:
+    ffmpeg:
+      input_args: preset-rtsp-restream -analyzeduration 1000000 -probesize 1000000
+      inputs:
+        - path: rtsp://127.0.0.1:8554/feeder
+          roles:
+            - record
+    detect:
+      enabled: false
+    motion:
+      enabled: true
+    record:
+      enabled: true
+```
+
+The only difference is the `go2rtc` part at the top: Option B adds a second
+stream that converts the video, and the camera then reads that converted one.
+
+---
+
+## Why these settings
+
+These are measurements from a real feeder on a small Intel home server. Your own
+numbers will be different, but the differences between the options should look
+similar.
+
+| How the stream is set up | Time until a picture appears | Processor use |
+|---|---|---|
+| convert video, re-encode audio | 3.0s | 0.94 of a core |
+| keep video, re-encode audio | 6.5s | 0.06 of a core |
+| **no conversion (Option A)** | 3.8s | **0.03 of a core** |
+| **convert video, keep audio (Option B)** | **3.0s** | 0.87 of a core |
+
+What this means in plain terms:
+
+- **Converting the video is the expensive part** — about a whole processor core,
+  continuously, for one camera. If you only want recordings, don't convert:
+  Frigate stores the original perfectly well.
+- **If you do convert, leave the audio alone.** Re-encoding the sound as well
+  costs a little extra and gains nothing.
+- **The `analyzeduration` and `probesize` numbers matter.** They tell Frigate how
+  long to spend working out what the stream is. This camera sends few pictures
+  per second, so the normal setting is over-generous — one second brings the
+  startup delay down from about 3 seconds to about 2. Do not set them much lower
+  than this: if the value is very small, Frigate cannot work the stream out at
+  all and waits forever.
+
+---
+
+## Object detection
+
+Both configurations above have detection switched **off** on purpose.
+
+The feeder's camera is tall rather than wide (1080 x 1920) and sends few pictures
+per second, and running detection on top of a conversion is expensive. Recording
+plus motion detection is usually the better trade.
+
+If you do want object detection, give it a size — and remember the picture is
+tall, so the height must be **larger** than the width:
+
+```yaml
+    detect:
+      enabled: true
+      width: 270
+      height: 480
+      fps: 2
+```
+
+Frigate assumes a normal wide picture by default, and that alone is enough to
+stop the detection stream from working.
+
+---
+
+## Talking through the feeder
+
+The connection supports talking back to the feeder, but **converting the video
+switches it off** — the conversion drops the microphone channel.
+
+If two-way audio matters to you, point your live view at the unconverted stream
+(`feeder_source` in Option B) rather than the converted one.
+
+---
+
+## If it does not work
+
+**"Connection refused"** — nearly always `127.0.0.1:8560` instead of Home
+Assistant's real address. See [the mistake almost everyone makes](#the-mistake-almost-everyone-makes).
+Also check Camera streaming is set to "Always on".
+
+**"No frames have been received"** — usually object detection. Switch it off, or
+give it a tall size as shown above.
+
+**It only starts after a long wait, or works on and off** — turn on Preload, and
+make sure the `analyzeduration` and `probesize` settings are present. Connecting
+over and over in quick succession can also be refused by the camera; preloading
+avoids reconnecting at all.
+
+**Nothing works after restarting Home Assistant** — the connection to the camera
+is rebuilt from scratch, which takes a moment. Preload plus "Always on" keeps
+that delay away from your recorder.


### PR DESCRIPTION
Pointing a recorder at the feeder meant digging the camera's address out of debug logs and guessing the rest. Two people reached a stream that would not start, both for the same reason: the bridge runs inside **Home Assistant**, so `127.0.0.1` from the recorder's point of view is the recorder itself.

- **"Camera stream address" diagnostic entity** (off by default) giving the exact address a recorder needs.
- **Diagnostics** now include that address plus a **ready-to-paste Frigate configuration** for the cameras actually present.
- **[docs/nvr.md](docs/nvr.md)** — the two settings to change first, a worked example with every address spelled out, two complete configurations to choose between, and measured figures for what each option costs.
- **On-demand idle time is now configurable** (1–60 min, default 5) instead of fixed.

### Being honest about the address

It is only trustworthy when Home Assistant has been told its own URL. Auto-detection returns whatever the host sees — inside a container that is the container's own address, useless to anything else. So both the entity and diagnostics report `address_source` (`configured`/`detected`) and attach a plain note when the value looks unusable, rather than presenting a guess as fact.

Verified on a bridge-networked install, where detection yields `172.17.0.3`: the note appears. Loopback, link-local and Docker's `172.16.0.0/12` are all treated as unusable; ordinary LAN addresses and hostnames are accepted.

### Measured, not assumed

The doc's guidance comes from benchmarking a real feeder rather than intuition:

| Stream setup | First picture | CPU |
|---|---|---|
| convert video + re-encode audio | 3.0s | 0.94 core |
| **no conversion (record only)** | 3.8s | **0.03 core** |
| **convert video, copy audio** | **3.0s** | 0.87 core |

Converting video costs about a full core per camera continuously, so record-only setups should not convert at all. `analyzeduration`/`probesize` around one second takes startup from 3.0s to 2.0s — but set very low and ffmpeg cannot identify the stream and hangs, so the doc gives a concrete value.