### PR TITLE
Review every pull request with Gemini Code Assist

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,32 @@
+# Gemini Code Assist for GitHub — automatic review on every pull request.
+#
+# Free for public repositories; it runs as a GitHub App, so there is no workflow
+# and no API key. Install it once for the repository and it reviews from the
+# next pull request onwards:
+#   https://github.com/apps/gemini-code-assist
+#
+# Full schema:
+#   https://docs.cloud.google.com/gemini/docs/code-review/customize-repo-review
+
+have_fun: false
+
+code_review:
+  disable: false
+  # MEDIUM and up. LOW buries a real finding under style opinions, and a review
+  # nobody reads is worse than no review.
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+    include_drafts: false
+
+# Vendored and generated code: not ours to review, and large enough to crowd
+# out everything that is.
+ignore_patterns:
+  - "custom_components/philips_pet_series/tuya_mobile/**"
+  - "custom_components/philips_pet_series/bin/**"
+  - "custom_components/philips_pet_series/translations/**"
+  - "**/__pycache__/**"
+  - "docs/screenshots/**"

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,68 @@
+# Review guide
+
+This is a Home Assistant custom integration for Philips Pet Series pet feeders,
+talking to Philips' cloud and to the device's Tuya datapoints. It ships Lovelace
+cards inside the integration.
+
+Review against what this project actually cares about, in this order.
+
+## Correctness against a real device
+
+The interesting bugs here are not type errors, they are wrong assumptions about
+hardware and about Home Assistant.
+
+- **Unique IDs are load-bearing.** Changing an entity's `unique_id` silently
+  orphans a user's history and renames their entity. A change to one needs a
+  migration in `_async_migrate_unique_ids`.
+- **Datapoint numbers are not interchangeable.** DP 101 and DP 201 both dispense
+  food, on different models. Flag any code that hardcodes one where the model is
+  not already known.
+- **Anything that dispenses food is a physical action.** Flag paths that could
+  fire it without a deliberate user action, or fire it more than once per action.
+- **Cloud data is often missing rather than wrong.** Prefer code that treats an
+  absent value as absent over code that substitutes a default that looks real.
+
+## Honest failure
+
+- A budget, cap or timeout that a user can hit must name the budget, the limit
+  and the ask when it is hit. Silent truncation and silent fallbacks are bugs.
+- Empty output is not a success state. A card that renders blank, a sensor that
+  reports `unknown` where the API actually returned something, or a registration
+  step that skips itself without logging are all worth a comment.
+- If a code path cannot do what was asked, it should say so in the log, with the
+  concrete thing the user would need to do.
+
+## Comments earn their place
+
+Comments here explain *why*, not *what*. A comment restating the code is noise;
+one recording a measurement, an API quirk or a rejected alternative is the point.
+Do not ask for docstrings on self-evident code, and do not ask for comments to be
+removed just because they are long, if they carry a reason.
+
+## Frontend (`frontend/philips-pet-series-cards.js`)
+
+- No build step by design. It borrows Lit from the page and must stay loadable as
+  a plain ES module. Flag anything needing bundling or a package manager.
+- Cards must not guess entity IDs. They resolve entities through the
+  `philips_pet_series/devices` websocket command, because users rename entities.
+- Cards must survive a device that lacks an entity: a feeder with no camera, no
+  filter, no MCU. Flag unguarded access to an optional role.
+- Colours come from the `--pps-*` custom properties or the user's theme. Flag
+  hardcoded colours that will break one of light or dark mode.
+- Anything animated must be gated on both the `animations` option and
+  `prefers-reduced-motion`.
+
+## Not worth a comment
+
+- Formatting, import order, and line length. There is no formatter in CI.
+- British vs American spelling. Both appear; it is not worth churn.
+- Suggestions to add a test framework, type annotations or a linter wholesale.
+  Propose those as an issue, not as a review comment on unrelated work.
+- Praise. A summary of what changed is useful; a paragraph on how good it is is
+  not.
+
+## Severity
+
+Reserve HIGH and CRITICAL for: something that can dispense food unintentionally,
+something that loses or orphans user data, a credential or token leak, or a
+change that breaks an existing user's entities or dashboards.


### PR DESCRIPTION
Adds automatic AI review to every PR, using **[Gemini Code Assist for GitHub](https://github.com/apps/gemini-code-assist)**.

Chosen because it is free for public repositories, runs as a GitHub App rather than a workflow, and therefore needs no API key held as a repository secret and nothing to maintain in CI.

## What is in the PR

- `.gemini/config.yaml` — severity threshold at `MEDIUM`, summary on PR open, drafts skipped, vendored and generated directories excluded from review.
- `.gemini/styleguide.md` — what to review this repository against.

## Why a style guide rather than the defaults

A generic reviewer on this repository would spend its comments on import order and missing docstrings, which is exactly the kind of review people learn to scroll past. The guide points it at what actually goes wrong here:

- unique IDs that silently orphan a user's history and rename their entities
- datapoint numbers that mean different things on different feeder models
- any path that could dispense food without a deliberate user action
- failures that are silent rather than loud — blank cards, skipped registration, defaults substituted for missing cloud data

It also states what *not* to comment on, and reserves HIGH/CRITICAL for the four things that genuinely warrant it.

## One manual step

The app has to be installed on the repository once — that is an account-level authorisation, so it needs a human:

https://github.com/apps/gemini-code-assist

Once installed, reviews start from the next PR. Nothing else to configure.