### PR TITLE
Point the cards' documentation link at docs that exist

### DIFF
--- a/custom_components/philips_pet_series/frontend/philips-pet-series-cards.js
+++ b/custom_components/philips_pet_series/frontend/philips-pet-series-cards.js
@@ -2380,7 +2380,10 @@ for (const [type, card, editor, name, description] of CARDS) {
     name,
     description,
     preview: true,
+    // The README section, not a wiki page: this is the link behind
+    // "documentation" in the card picker, and it has to resolve to something
+    // that actually describes the cards.
     documentationURL:
-      "https://github.com/AboveColin/HA-Philips-Pet-Series/wiki/Lovelace-cards",
+      "https://github.com/AboveColin/HA-Philips-Pet-Series#the-dashboard-cards",
   });
 }


### PR DESCRIPTION
Each custom card advertises a `documentationURL`, which is the **documentation** link the Lovelace card picker shows next to it. All three pointed at `wiki/Lovelace-cards`, which was never written — GitHub 302s it to the wiki index, so anyone following it had to go hunting.

Verified before and after:

```
wiki/Lovelace-cards  ->  302  ->  https://github.com/AboveColin/HA-Philips-Pet-Series/wiki/   (index)
#the-dashboard-cards ->  200                                                                  (the card docs)
```

The README section covers all three cards, every option, the sizes, the colour variables and the motion settings, so it is the honest target.

---

Incidentally the first PR opened since Gemini Code Assist was installed, so it doubles as a check that the reviewer runs and honours `.gemini/`.