### PR TITLE
Report firmware as an update entity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      # No Home Assistant install: the modules under test are deliberately free
+      # of Home Assistant imports, which is what keeps this job to a few seconds
+      # instead of pulling the whole framework.
+      - run: pip install pytest
+
+      - run: python -m pytest tests -q

--- a/custom_components/philips_pet_series/__init__.py
+++ b/custom_components/philips_pet_series/__init__.py
@@ -48,7 +48,7 @@ from .const import (
     DOMAIN,
     REMOVED_DP_SENSORS,
 )
-from . import websocket
+from . import firmware, websocket
 from .bridge import PhilipsCameraBridgeManager
 from .frontend import JSModuleRegistration
 from .lanbeacon import BeaconListener
@@ -65,6 +65,7 @@ PLATFORMS = [
     Platform.CALENDAR,
     Platform.IMAGE,
     Platform.CAMERA,
+    Platform.UPDATE,
 ]
 
 SCAN_INTERVAL = timedelta(minutes=5)
@@ -626,16 +627,17 @@ def _async_remove_stale_entities(hass: HomeAssistant, entry: ConfigEntry) -> Non
     # The MCU firmware sensor is only created for hardware that reports an MCU
     # module, so drop it for devices that do not -- but leave it untouched on
     # devices where it is still provided.
-    coordinator = (hass.data.get(DOMAIN, {}).get(entry.entry_id) or {}).get("coordinator")
+    coordinator = (hass.data.get(DOMAIN, {}).get(entry.entry_id) or {}).get(
+        "coordinator"
+    )
     data = getattr(coordinator, "data", None) or {}
     for device in data.get("devices", []):
-        definition = data.get("device_definitions", {}).get(device.id)
-        module_map = {}
-        if isinstance(definition, dict) and isinstance(definition.get("otaInfo"), dict):
-            module_map = definition["otaInfo"].get("otaModuleMap") or {}
-        mcu = module_map.get("mcu") if isinstance(module_map, dict) else None
-        if not (isinstance(mcu, dict) and mcu.get("verSw")):
+        if coordinator is None or not firmware.has_ota_module(coordinator, device, "mcu"):
+            # Both the version sensor and the update entity are created only for
+            # hardware that reports an MCU module, so both have to be dropped
+            # for hardware that does not.
             stale_unique_ids.add(f"{device.id}_mcu_firmware_version")
+            stale_unique_ids.add(f"{device.id}_mcu_firmware_update")
 
     for registry_entry in list(registry.entities.values()):
         if registry_entry.config_entry_id != entry.entry_id:

--- a/custom_components/philips_pet_series/__init__.py
+++ b/custom_components/philips_pet_series/__init__.py
@@ -632,7 +632,12 @@ def _async_remove_stale_entities(hass: HomeAssistant, entry: ConfigEntry) -> Non
     )
     data = getattr(coordinator, "data", None) or {}
     for device in data.get("devices", []):
-        if coordinator is None or not firmware.has_ota_module(coordinator, device, "mcu"):
+        # Only act on a definite answer.  Deleting a registry row throws away the
+        # user's history, so "we could not read the module list this time" must
+        # not be treated the same as "this feeder has no MCU".
+        if not firmware.reports_ota_modules(coordinator, device.id):
+            continue
+        if not firmware.has_ota_module(coordinator, device, "mcu"):
             # Both the version sensor and the update entity are created only for
             # hardware that reports an MCU module, so both have to be dropped
             # for hardware that does not.

--- a/custom_components/philips_pet_series/firmware.py
+++ b/custom_components/philips_pet_series/firmware.py
@@ -1,0 +1,134 @@
+"""Shared firmware and OTA lookups.
+
+The firmware sensors and the update entities need the same three things out of
+the coordinator: what the device reports it is running, what Tuya has on offer,
+and the raw OTA record behind both.  Keeping that here means the two can never
+disagree about a version.
+"""
+
+from __future__ import annotations
+
+# Tuya's OTA record "type", per module.  The wireless module and the MCU are
+# offered separately, so a record for one says nothing about the other.
+_OTA_TYPES = {"wifi": 0, "mcu": 9}
+
+# Observed values of "upgradeStatus": 0 means nothing is on offer, and Tuya only
+# publishes the package URL while it is non-zero.  1 is an offer.  Higher values
+# presumably describe an update in flight, but none has ever been seen on these
+# feeders, so nothing here pretends to know what they mean.
+STATUS_UPDATE_AVAILABLE = 1
+
+
+def _data(coordinator) -> dict:
+    """The coordinator's payload, or an empty one.
+
+    Called from the stale-entity sweep as well as from entities, and that runs
+    early enough that the first refresh may not have landed yet.
+    """
+    return getattr(coordinator, "data", None) or {}
+
+
+def device_definition(coordinator, device_id) -> dict:
+    """Tuya device metadata (``thing.m.device.get``) for one device."""
+    definition = _data(coordinator).get("device_definitions", {}).get(device_id)
+    return definition if isinstance(definition, dict) else {}
+
+
+def ota_module(coordinator, device_id, component: str) -> dict:
+    """Per-module OTA record, when the device reports one.
+
+    Devices expose ``otaInfo.otaModuleMap`` keyed by module name ("wifi",
+    "mcu").  Feeders without a separate microcontroller list only "wifi", in
+    which case there is genuinely no MCU version to report.
+    """
+    ota_info = device_definition(coordinator, device_id).get("otaInfo")
+    if not isinstance(ota_info, dict):
+        return {}
+    module_map = ota_info.get("otaModuleMap")
+    if not isinstance(module_map, dict):
+        return {}
+    module = module_map.get(component)
+    return module if isinstance(module, dict) else {}
+
+
+def has_ota_module(coordinator, device, component: str) -> bool:
+    """Whether the device's metadata reports an OTA module by this name."""
+    return bool(ota_module(coordinator, device.id, component).get("verSw"))
+
+
+def ota_record(coordinator, device_id, component: str) -> tuple[dict, bool]:
+    """The OTA record for a component, and whether it came from stored history.
+
+    Returns ``({}, False)`` when Tuya has told us nothing about this module.
+    History is only consulted when the live endpoints returned nothing, because
+    a signed package URL is short-lived and worth keeping once seen.
+    """
+    wanted = _OTA_TYPES.get(component)
+    if wanted is None:
+        return {}, False
+
+    data = _data(coordinator)
+    records = data.get("firmware_info", {}).get(device_id, []) + (
+        data.get("product_firmware_info", {}).get(device_id, [])
+    )
+    from_history = not records
+    if from_history:
+        records = data.get("ota_history", {}).get(device_id, [])
+
+    for record in records:
+        try:
+            if int(record.get("type", -1)) == wanted:
+                return record, from_history
+        except (TypeError, ValueError):
+            continue
+    return {}, False
+
+
+def installed_version(coordinator, device, component: str) -> str | None:
+    """The version this module is currently running, from the best source.
+
+    The OTA endpoints are frequently unauthorised for third-party logins, so
+    this walks from the most authoritative source to the least rather than
+    trusting any single one.
+    """
+    record, _ = ota_record(coordinator, device.id, component)
+    version = record.get("currentVersion") or record.get("current_version")
+    if version:
+        return version
+
+    module_version = ota_module(coordinator, device.id, component).get("verSw")
+    if module_version:
+        return module_version
+
+    if component == "wifi":
+        # ``verSw`` on the device record is the wireless module firmware, which
+        # is the version the Philips app shows for the device.
+        definition_version = device_definition(coordinator, device.id).get("verSw")
+        if definition_version:
+            return definition_version
+
+    value = getattr(device, f"{component}_version", None)
+    if value:
+        return value
+
+    status = _data(coordinator).get("settings", {}).get(device.id, {}).get(
+        "tuya_status", {}
+    )
+    if isinstance(status, dict):
+        for key in (f"{component}Version", f"{component}_version", component):
+            if status.get(key) is not None:
+                return str(status[key])
+    return None
+
+
+def offered_version(coordinator, device, component: str) -> str | None:
+    """The version Tuya is offering, or None when nothing is on offer."""
+    record, _ = ota_record(coordinator, device.id, component)
+    if not record:
+        return None
+    try:
+        if int(record.get("upgradeStatus", 0)) != STATUS_UPDATE_AVAILABLE:
+            return None
+    except (TypeError, ValueError):
+        return None
+    return record.get("version") or None

--- a/custom_components/philips_pet_series/firmware.py
+++ b/custom_components/philips_pet_series/firmware.py
@@ -19,6 +19,27 @@ _OTA_TYPES = {"wifi": 0, "mcu": 9}
 STATUS_UPDATE_AVAILABLE = 1
 
 
+def _upgrade_status(record) -> int | None:
+    """``upgradeStatus`` as an int, or None when absent or unparseable.
+
+    Tuya has been seen returning this field as a number and as a numeric
+    string, so both callers have to agree on how it is read or they will
+    disagree about whether an update exists.
+    """
+    raw = record.get("upgradeStatus")
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def is_offer(record) -> bool:
+    """Whether this record describes an update Tuya is currently offering."""
+    return _upgrade_status(record) == STATUS_UPDATE_AVAILABLE
+
+
 def _data(coordinator) -> dict:
     """The coordinator's payload, or an empty one.
 
@@ -56,12 +77,32 @@ def has_ota_module(coordinator, device, component: str) -> bool:
     return bool(ota_module(coordinator, device.id, component).get("verSw"))
 
 
-def ota_record(coordinator, device_id, component: str) -> tuple[dict, bool]:
+def reports_ota_modules(coordinator, device_id) -> bool:
+    """Whether we actually have this device's module list.
+
+    False means "we do not know", which is not the same as "the device has no
+    such module".  Anything destructive has to tell those two apart: a metadata
+    fetch that failed once would otherwise look like hardware that lost a
+    component.
+    """
+    ota_info = device_definition(coordinator, device_id).get("otaInfo")
+    return isinstance(ota_info, dict) and isinstance(
+        ota_info.get("otaModuleMap"), dict
+    )
+
+
+def ota_record(
+    coordinator, device_id, component: str, *, include_history: bool = True
+) -> tuple[dict, bool]:
     """The OTA record for a component, and whether it came from stored history.
 
     Returns ``({}, False)`` when Tuya has told us nothing about this module.
     History is only consulted when the live endpoints returned nothing, because
     a signed package URL is short-lived and worth keeping once seen.
+
+    Pass ``include_history=False`` for any question about the present.  A stored
+    record is a snapshot of something Tuya said once, so it cannot establish
+    what is true now.
     """
     wanted = _OTA_TYPES.get(component)
     if wanted is None:
@@ -73,7 +114,7 @@ def ota_record(coordinator, device_id, component: str) -> tuple[dict, bool]:
     )
     from_history = not records
     if from_history:
-        records = data.get("ota_history", {}).get(device_id, [])
+        records = data.get("ota_history", {}).get(device_id, []) if include_history else []
 
     for record in records:
         try:
@@ -89,10 +130,12 @@ def installed_version(coordinator, device, component: str) -> str | None:
 
     The OTA endpoints are frequently unauthorised for third-party logins, so
     this walks from the most authoritative source to the least rather than
-    trusting any single one.
+    trusting any single one.  Every live source is tried before the stored one,
+    because a kept record can be arbitrarily old and would otherwise pin the
+    version to whatever it said months ago.
     """
-    record, _ = ota_record(coordinator, device.id, component)
-    version = record.get("currentVersion") or record.get("current_version")
+    live, _ = ota_record(coordinator, device.id, component, include_history=False)
+    version = live.get("currentVersion") or live.get("current_version")
     if version:
         return version
 
@@ -118,17 +161,21 @@ def installed_version(coordinator, device, component: str) -> str | None:
         for key in (f"{component}Version", f"{component}_version", component):
             if status.get(key) is not None:
                 return str(status[key])
-    return None
+
+    # Last resort: a record kept from an earlier offer.  Better than reporting
+    # nothing, but every live source above is preferred over it.
+    stored, _ = ota_record(coordinator, device.id, component)
+    return stored.get("currentVersion") or stored.get("current_version") or None
 
 
 def offered_version(coordinator, device, component: str) -> str | None:
-    """The version Tuya is offering, or None when nothing is on offer."""
-    record, _ = ota_record(coordinator, device.id, component)
-    if not record:
-        return None
-    try:
-        if int(record.get("upgradeStatus", 0)) != STATUS_UPDATE_AVAILABLE:
-            return None
-    except (TypeError, ValueError):
+    """The version Tuya is offering right now, or None.
+
+    Live records only.  A stored record that once carried an offer would
+    otherwise keep claiming an update forever, long after Philips stopped
+    serving it.
+    """
+    record, _ = ota_record(coordinator, device.id, component, include_history=False)
+    if not record or not is_offer(record):
         return None
     return record.get("version") or None

--- a/custom_components/philips_pet_series/sensor.py
+++ b/custom_components/philips_pet_series/sensor.py
@@ -22,6 +22,7 @@ from petsseries.api import PetsSeriesClient
 from . import DOMAIN, PhilipsPetsSeriesDataUpdateCoordinator
 from .const import REMOVED_DP_SENSORS  # noqa: F401  (documented alongside _READ_ONLY_TUYA_DPS)
 from .datapoints import datapoints
+from . import firmware
 from .entity import PhilipsPetsSeriesEntity, iter_home_devices
 from .meals import device_meals, next_occurrence as next_meal, occurrences
 
@@ -54,21 +55,6 @@ _READ_ONLY_TUYA_DPS = {
 # the device page unless somebody deliberately turns them on.
 _DISABLED_BY_DEFAULT_DPS = ("206",)
 
-def _has_ota_module(coordinator, device, module: str) -> bool:
-    """Whether the device's metadata reports an OTA module by this name."""
-    definition = coordinator.data.get("device_definitions", {}).get(device.id)
-    if not isinstance(definition, dict):
-        return False
-    ota_info = definition.get("otaInfo")
-    if not isinstance(ota_info, dict):
-        return False
-    module_map = ota_info.get("otaModuleMap")
-    if not isinstance(module_map, dict):
-        return False
-    entry = module_map.get(module)
-    return isinstance(entry, dict) and bool(entry.get("verSw"))
-
-
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -98,7 +84,7 @@ async def async_setup_entry(
         # Only offer an MCU version where the hardware reports one; feeders
         # without a separate microcontroller list a wireless module only, and a
         # permanently empty sensor is worse than no sensor.
-        if _has_ota_module(coordinator, device, "mcu"):
+        if firmware.has_ota_module(coordinator, device, "mcu"):
             sensors.append(PhilipsPetsSeriesFirmwareSensor(coordinator, home, device, "mcu"))
         sensors.append(PhilipsPetsSeriesFirmwareSensor(coordinator, home, device, "wifi"))
         sensors.extend(
@@ -150,101 +136,49 @@ class PhilipsPetsSeriesFirmwareSensor(PhilipsPetsSeriesEntity, SensorEntity):
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_icon = "mdi:chip" if component == "mcu" else "mdi:wifi"
 
-    def _device_definition(self) -> dict:
-        """Tuya device metadata (``thing.m.device.get``) for this device."""
-        definition = self.coordinator.data.get("device_definitions", {}).get(
-            self._device.id
-        )
-        return definition if isinstance(definition, dict) else {}
-
-    def _ota_module(self) -> dict:
-        """Per-module OTA record for this component, when the device reports one.
-
-        Devices expose ``otaInfo.otaModuleMap`` keyed by module name ("wifi",
-        "mcu").  Feeders without a separate microcontroller only list "wifi",
-        in which case there is genuinely no MCU version to report.
-        """
-        ota_info = self._device_definition().get("otaInfo")
-        if not isinstance(ota_info, dict):
-            return {}
-        module_map = ota_info.get("otaModuleMap")
-        if not isinstance(module_map, dict):
-            return {}
-        module = module_map.get(self._component)
-        return module if isinstance(module, dict) else {}
-
     @property
     def native_value(self):
-        ota_type = 9 if self._component == "mcu" else 0
-        records = (
-            self.coordinator.data.get("firmware_info", {}).get(self._device.id, [])
-            + self.coordinator.data.get("product_firmware_info", {}).get(self._device.id, [])
+        """The version this module is running."""
+        return firmware.installed_version(
+            self.coordinator, self._device, self._component
         )
-        if not records:
-            records = self.coordinator.data.get("ota_history", {}).get(self._device.id, [])
-        for record in records:
-            try:
-                if int(record.get("type", -1)) == ota_type:
-                    version = record.get("currentVersion") or record.get("current_version")
-                    if version:
-                        return version
-            except (TypeError, ValueError):
-                continue
-        # The OTA endpoints are frequently unauthorised for third-party logins,
-        # so fall back to the version the device metadata reports directly.
-        module_version = self._ota_module().get("verSw")
-        if module_version:
-            return module_version
-        if self._component == "wifi":
-            # ``verSw`` on the device record is the wireless module firmware,
-            # which is the version the Philips app shows for the device.
-            definition_version = self._device_definition().get("verSw")
-            if definition_version:
-                return definition_version
-        value = getattr(self._device, f"{self._component}_version", None)
-        if value:
-            return value
-        status = self.coordinator.data.get("settings", {}).get(self._device.id, {}).get("tuya_status", {})
-        for key in (f"{self._component}Version", f"{self._component}_version", self._component):
-            if status.get(key) is not None:
-                return str(status[key])
-        return None
 
     @property
     def extra_state_attributes(self):
-        ota_type = 9 if self._component == "mcu" else 0
-        records = (
-            self.coordinator.data.get("firmware_info", {}).get(self._device.id, [])
-            + self.coordinator.data.get("product_firmware_info", {}).get(self._device.id, [])
+        """The raw OTA record, unchanged, for anyone decoding what Philips sent.
+
+        Kept whole rather than trimmed: these keys are what the Tuya endpoints
+        actually return, and somebody templating against them should see the
+        same names.
+        """
+        record, captured = firmware.ota_record(
+            self.coordinator, self._device.id, self._component
         )
-        captured = not records
-        if not records:
-            records = self.coordinator.data.get("ota_history", {}).get(self._device.id, [])
-        for record in records:
-            try:
-                if int(record.get("type", -1)) == ota_type:
-                    return {
-                        "ota_type": record.get("type"),
-                        "version": record.get("version"),
-                        "current_version": record.get("currentVersion") or record.get("current_version"),
-                        "available_version": record.get("version"),
-                        "upgrade_status": record.get("upgradeStatus"),
-                        "upgrade_type": record.get("upgradeType"),
-                        "upgrade_mode": record.get("upgradeMode"),
-                        "can_upgrade": record.get("canUpgrade"),
-                        "url": record.get("url"),
-                        "file_size": record.get("fileSize"),
-                        "md5": record.get("md5"),
-                        "sign": record.get("sign"),
-                        "hmac": record.get("hmac"),
-                        "file_path": record.get("filePath"),
-                        "diff_ota": record.get("diffOta"),
-                        "update_available": record.get("upgradeStatus") == 1,
-                        "captured_from_history": captured,
-                    }
-            except (TypeError, ValueError):
-                continue
-        return None
+        if not record:
+            return None
+        return {
+            "ota_type": record.get("type"),
+            "version": record.get("version"),
+            "current_version": (
+                record.get("currentVersion") or record.get("current_version")
+            ),
+            "available_version": record.get("version"),
+            "upgrade_status": record.get("upgradeStatus"),
+            "upgrade_type": record.get("upgradeType"),
+            "upgrade_mode": record.get("upgradeMode"),
+            "can_upgrade": record.get("canUpgrade"),
+            "url": record.get("url"),
+            "file_size": record.get("fileSize"),
+            "md5": record.get("md5"),
+            "sign": record.get("sign"),
+            "hmac": record.get("hmac"),
+            "file_path": record.get("filePath"),
+            "diff_ota": record.get("diffOta"),
+            "update_available": (
+                record.get("upgradeStatus") == firmware.STATUS_UPDATE_AVAILABLE
+            ),
+            "captured_from_history": captured,
+        }
 
 
 class PhilipsPetsSeriesRawDpSensor(PhilipsPetsSeriesEntity, SensorEntity):

--- a/custom_components/philips_pet_series/sensor.py
+++ b/custom_components/philips_pet_series/sensor.py
@@ -174,9 +174,9 @@ class PhilipsPetsSeriesFirmwareSensor(PhilipsPetsSeriesEntity, SensorEntity):
             "hmac": record.get("hmac"),
             "file_path": record.get("filePath"),
             "diff_ota": record.get("diffOta"),
-            "update_available": (
-                record.get("upgradeStatus") == firmware.STATUS_UPDATE_AVAILABLE
-            ),
+            # A stored record cannot establish that an update is on offer now,
+            # only that one was, so a historical record never reads available.
+            "update_available": not captured and firmware.is_offer(record),
             "captured_from_history": captured,
         }
 

--- a/custom_components/philips_pet_series/update.py
+++ b/custom_components/philips_pet_series/update.py
@@ -1,0 +1,128 @@
+"""Firmware update entities.
+
+Read-only by design.  Probing the Tuya upgrade endpoints with a Philips
+third-party OAuth token returns PERMISSION_DENIED for
+``thing.m.device.upgrade.info`` and ``.auto.switch.get``, so this integration
+cannot start an update even when one is on offer.  An install button that always
+fails is worse than no button, so the entity reports versions and leaves
+installing to the Philips app.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.update import (
+    UpdateDeviceClass,
+    UpdateEntity,
+    UpdateEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DOMAIN, PhilipsPetsSeriesDataUpdateCoordinator
+from . import firmware
+from .entity import PhilipsPetsSeriesEntity, iter_home_devices
+
+_LOGGER = logging.getLogger(__name__)
+
+# The modules a feeder can report, and how to label them.  "wifi" is always
+# present; a feeder without a separate microcontroller never reports "mcu", and a
+# permanently empty entity is worse than no entity.
+_COMPONENTS = {
+    "wifi": ("WiFi firmware", "mdi:wifi"),
+    "mcu": ("MCU firmware", "mdi:chip"),
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up one update entity per firmware module the feeder reports."""
+    coordinator: PhilipsPetsSeriesDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]["coordinator"]
+
+    entities = []
+    for home, device in iter_home_devices(coordinator):
+        for component in _COMPONENTS:
+            if component == "mcu" and not firmware.has_ota_module(
+                coordinator, device, "mcu"
+            ):
+                continue
+            entities.append(
+                PhilipsPetsSeriesFirmwareUpdate(coordinator, home, device, component)
+            )
+
+    async_add_entities(entities)
+
+
+class PhilipsPetsSeriesFirmwareUpdate(PhilipsPetsSeriesEntity, UpdateEntity):
+    """What a firmware module is running, and what Philips has on offer."""
+
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    # Deliberately no UpdateEntityFeature.INSTALL; see the module docstring.
+    _attr_supported_features = UpdateEntityFeature(0)
+
+    def __init__(self, coordinator, home, device, component: str) -> None:
+        """Initialise the update entity for one firmware module."""
+        super().__init__(coordinator, device, home)
+        self._component = component
+        name, icon = _COMPONENTS[component]
+        self._attr_unique_id = f"{device.id}_{component}_firmware_update"
+        self._attr_name = name
+        self._attr_icon = icon
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def installed_version(self) -> str | None:
+        """The version the module is running now."""
+        return firmware.installed_version(self.coordinator, self._device, self._component)
+
+    @property
+    def latest_version(self) -> str | None:
+        """The offered version, or the installed one when nothing is on offer.
+
+        Reporting None would render as "unknown" rather than "up to date", which
+        reads as a fault on a feeder that is simply current.  Tuya publishes an
+        offer only while ``upgradeStatus`` is non-zero, so no offer genuinely
+        means there is nothing newer that we can see.
+        """
+        offered = firmware.offered_version(
+            self.coordinator, self._device, self._component
+        )
+        return offered or self.installed_version
+
+    @property
+    def release_summary(self) -> str | None:
+        """Say where an update has to be installed, since it cannot be here."""
+        if not firmware.offered_version(
+            self.coordinator, self._device, self._component
+        ):
+            return None
+        return (
+            "Philips does not let a third-party login start an update, so install "
+            "this one from the Philips Pet Series app."
+        )
+
+    @property
+    def extra_state_attributes(self):
+        """The raw OTA record, for anyone wanting to see what Philips offered."""
+        record, from_history = firmware.ota_record(
+            self.coordinator, self._device.id, self._component
+        )
+        if not record:
+            return None
+        return {
+            "upgrade_status": record.get("upgradeStatus"),
+            "upgrade_type": record.get("upgradeType"),
+            "file_size": record.get("fileSize"),
+            "md5": record.get("md5"),
+            # A signed package URL is short-lived, so it is worth knowing whether
+            # this record is live or was kept from an earlier offer.
+            "captured_from_history": from_history,
+        }

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -1,0 +1,248 @@
+"""Tests for the firmware and OTA lookups.
+
+`firmware.py` deliberately imports nothing from Home Assistant, so these run
+under plain pytest with no test harness.
+
+The fallback chain in `installed_version` is the part worth testing: the Tuya OTA
+endpoints are unauthorised for most third-party logins, so in practice the
+version comes from a different source on almost every install, and there is no
+way to notice a broken rung by looking at one device.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Loaded straight from the file rather than as `philips_pet_series.firmware`,
+# because importing the package runs its __init__, which needs Home Assistant.
+# Keeping this import path is what lets the suite run anywhere.
+_MODULE = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "philips_pet_series"
+    / "firmware.py"
+)
+_spec = importlib.util.spec_from_file_location("pps_firmware", _MODULE)
+firmware = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(firmware)
+
+
+class FakeCoordinator:
+    """Just enough of the coordinator: it is only ever read from."""
+
+    def __init__(self, data):
+        self.data = data
+
+
+class FakeDevice:
+    def __init__(self, device_id="dev1", **attrs):
+        self.id = device_id
+        for key, value in attrs.items():
+            setattr(self, key, value)
+
+
+def definition(**ota_modules):
+    """A device_definitions payload shaped like Tuya's."""
+    return {
+        "dev1": {
+            "verSw": "definition-version",
+            "otaInfo": {"otaModuleMap": ota_modules},
+        }
+    }
+
+
+# --- ota_record -------------------------------------------------------------
+
+
+def test_record_is_matched_by_module_type():
+    """wifi is OTA type 0 and mcu is 9; a record for one is not the other."""
+    coordinator = FakeCoordinator(
+        {
+            "firmware_info": {
+                "dev1": [
+                    {"type": 0, "version": "wifi-1"},
+                    {"type": 9, "version": "mcu-1"},
+                ]
+            }
+        }
+    )
+    wifi, _ = firmware.ota_record(coordinator, "dev1", "wifi")
+    mcu, _ = firmware.ota_record(coordinator, "dev1", "mcu")
+    assert wifi["version"] == "wifi-1"
+    assert mcu["version"] == "mcu-1"
+
+
+def test_history_is_only_consulted_when_live_records_are_empty():
+    live = {"type": 0, "version": "live"}
+    stored = {"type": 0, "version": "stored"}
+
+    with_live = FakeCoordinator(
+        {"firmware_info": {"dev1": [live]}, "ota_history": {"dev1": [stored]}}
+    )
+    record, from_history = firmware.ota_record(with_live, "dev1", "wifi")
+    assert record["version"] == "live"
+    assert from_history is False
+
+    without_live = FakeCoordinator({"ota_history": {"dev1": [stored]}})
+    record, from_history = firmware.ota_record(without_live, "dev1", "wifi")
+    assert record["version"] == "stored"
+    assert from_history is True
+
+
+def test_unparseable_record_type_is_skipped_not_raised():
+    coordinator = FakeCoordinator(
+        {
+            "firmware_info": {
+                "dev1": [{"type": "junk"}, {"type": 0, "version": "good"}]
+            }
+        }
+    )
+    record, _ = firmware.ota_record(coordinator, "dev1", "wifi")
+    assert record["version"] == "good"
+
+
+def test_unknown_component_has_no_record():
+    coordinator = FakeCoordinator({"firmware_info": {"dev1": [{"type": 0}]}})
+    assert firmware.ota_record(coordinator, "dev1", "bluetooth") == ({}, False)
+
+
+# --- installed_version fallback chain ---------------------------------------
+
+
+def test_ota_record_current_version_wins():
+    coordinator = FakeCoordinator(
+        {
+            "firmware_info": {
+                "dev1": [{"type": 0, "currentVersion": "from-record"}]
+            },
+            "device_definitions": definition(wifi={"verSw": "from-module"}),
+        }
+    )
+    assert (
+        firmware.installed_version(coordinator, FakeDevice(), "wifi") == "from-record"
+    )
+
+
+def test_falls_back_to_the_module_map():
+    coordinator = FakeCoordinator(
+        {"device_definitions": definition(wifi={"verSw": "from-module"})}
+    )
+    assert (
+        firmware.installed_version(coordinator, FakeDevice(), "wifi") == "from-module"
+    )
+
+
+def test_definition_version_is_used_for_wifi_only():
+    """`verSw` on the device record is the wireless module's version.
+
+    Reading it for the MCU would report the wrong chip's firmware, which is
+    worse than reporting nothing.
+    """
+    coordinator = FakeCoordinator({"device_definitions": definition()})
+    assert (
+        firmware.installed_version(coordinator, FakeDevice(), "wifi")
+        == "definition-version"
+    )
+    assert firmware.installed_version(coordinator, FakeDevice(), "mcu") is None
+
+
+def test_falls_back_to_a_device_attribute():
+    coordinator = FakeCoordinator({})
+    device = FakeDevice(mcu_version="from-device")
+    assert firmware.installed_version(coordinator, device, "mcu") == "from-device"
+
+
+@pytest.mark.parametrize("key", ["wifiVersion", "wifi_version", "wifi"])
+def test_falls_back_to_tuya_status_under_any_spelling(key):
+    coordinator = FakeCoordinator(
+        {"settings": {"dev1": {"tuya_status": {key: 42}}}}
+    )
+    assert firmware.installed_version(coordinator, FakeDevice(), "wifi") == "42"
+
+
+def test_nothing_known_reports_nothing():
+    assert firmware.installed_version(FakeCoordinator({}), FakeDevice(), "wifi") is None
+
+
+def test_a_non_dict_tuya_status_does_not_raise():
+    """The fallback status dict is sometimes a list of code/value pairs."""
+    coordinator = FakeCoordinator({"settings": {"dev1": {"tuya_status": []}}})
+    assert firmware.installed_version(coordinator, FakeDevice(), "wifi") is None
+
+
+# --- offered_version --------------------------------------------------------
+
+
+def test_no_offer_while_upgrade_status_is_zero():
+    """The state every one of these feeders is actually in.
+
+    Tuya publishes a package URL only while upgradeStatus is non-zero, so a
+    record carrying a version but status 0 is not an offer.
+    """
+    coordinator = FakeCoordinator(
+        {
+            "firmware_info": {
+                "dev1": [{"type": 0, "version": "111.06.24", "upgradeStatus": 0}]
+            }
+        }
+    )
+    assert firmware.offered_version(coordinator, FakeDevice(), "wifi") is None
+
+
+def test_an_offer_reports_its_version():
+    coordinator = FakeCoordinator(
+        {
+            "firmware_info": {
+                "dev1": [{"type": 0, "version": "111.07.00", "upgradeStatus": 1}]
+            }
+        }
+    )
+    assert (
+        firmware.offered_version(coordinator, FakeDevice(), "wifi") == "111.07.00"
+    )
+
+
+def test_an_offer_without_a_version_is_not_an_offer():
+    coordinator = FakeCoordinator(
+        {"firmware_info": {"dev1": [{"type": 0, "upgradeStatus": 1}]}}
+    )
+    assert firmware.offered_version(coordinator, FakeDevice(), "wifi") is None
+
+
+def test_unparseable_upgrade_status_is_not_an_offer():
+    coordinator = FakeCoordinator(
+        {
+            "firmware_info": {
+                "dev1": [{"type": 0, "version": "x", "upgradeStatus": None}]
+            }
+        }
+    )
+    assert firmware.offered_version(coordinator, FakeDevice(), "wifi") is None
+
+
+# --- has_ota_module ---------------------------------------------------------
+
+
+def test_module_presence_requires_a_version():
+    """An empty module entry is not a module.
+
+    The MCU entities are created off this, and a feeder without a separate
+    microcontroller would otherwise get a permanently empty entity.
+    """
+    coordinator = FakeCoordinator({"device_definitions": definition(mcu={})})
+    assert firmware.has_ota_module(coordinator, FakeDevice(), "mcu") is False
+
+    coordinator = FakeCoordinator({"device_definitions": definition(mcu={"verSw": "1"})})
+    assert firmware.has_ota_module(coordinator, FakeDevice(), "mcu") is True
+
+
+# --- called before the first refresh ---------------------------------------
+
+
+@pytest.mark.parametrize("coordinator", [FakeCoordinator(None), None])
+def test_survives_being_asked_before_any_data_arrived(coordinator):
+    """The stale-entity sweep runs before the first refresh has landed."""
+    assert firmware.has_ota_module(coordinator, FakeDevice(), "mcu") is False
+    assert firmware.installed_version(coordinator, FakeDevice(), "wifi") is None
+    assert firmware.offered_version(coordinator, FakeDevice(), "wifi") is None

--- a/tests/test_firmware.py
+++ b/tests/test_firmware.py
@@ -246,3 +246,88 @@ def test_survives_being_asked_before_any_data_arrived(coordinator):
     assert firmware.has_ota_module(coordinator, FakeDevice(), "mcu") is False
     assert firmware.installed_version(coordinator, FakeDevice(), "wifi") is None
     assert firmware.offered_version(coordinator, FakeDevice(), "wifi") is None
+
+
+# --- stored records must not speak for the present ---------------------------
+# Regression cases from review of the update entity. A record kept from an
+# earlier offer is a snapshot, and treating it as current produced two visible
+# faults: a version frozen at whatever it said then, and an update that appeared
+# to be available forever.
+
+
+def test_a_stored_offer_is_not_a_current_offer():
+    """Otherwise the update entity claims an update for good.
+
+    ota_history exists to keep a short-lived signed package URL, so it will
+    routinely hold a record whose upgradeStatus was 1 at the time.
+    """
+    coordinator = FakeCoordinator(
+        {
+            "ota_history": {
+                "dev1": [{"type": 0, "version": "111.07.00", "upgradeStatus": 1}]
+            }
+        }
+    )
+    assert firmware.offered_version(coordinator, FakeDevice(), "wifi") is None
+
+
+def test_live_module_version_beats_a_stored_current_version():
+    coordinator = FakeCoordinator(
+        {
+            "device_definitions": definition(wifi={"verSw": "111.06.24"}),
+            "ota_history": {
+                "dev1": [{"type": 0, "currentVersion": "110.01.00"}]
+            },
+        }
+    )
+    assert (
+        firmware.installed_version(coordinator, FakeDevice(), "wifi") == "111.06.24"
+    )
+
+
+def test_a_stored_version_is_still_better_than_nothing():
+    coordinator = FakeCoordinator(
+        {"ota_history": {"dev1": [{"type": 0, "currentVersion": "110.01.00"}]}}
+    )
+    assert (
+        firmware.installed_version(coordinator, FakeDevice(), "wifi") == "110.01.00"
+    )
+
+
+# --- upgradeStatus is read one way everywhere -------------------------------
+
+
+@pytest.mark.parametrize("raw", [1, "1"])
+def test_an_offer_is_recognised_as_a_number_or_a_string(raw):
+    """Tuya has returned this field both ways.
+
+    The sensor attribute and the update entity have to agree, or one says an
+    update is available while the other says it is not.
+    """
+    assert firmware.is_offer({"upgradeStatus": raw}) is True
+
+
+@pytest.mark.parametrize("raw", [0, "0", None, "", "junk", [], 2])
+def test_anything_else_is_not_an_offer(raw):
+    assert firmware.is_offer({"upgradeStatus": raw}) is False
+
+
+# --- "we do not know" is not "it is absent" ---------------------------------
+
+
+def test_module_list_is_only_trusted_when_we_have_it():
+    """Guards a destructive path.
+
+    The stale-entity sweep deletes registry rows, taking the user's history with
+    them. A metadata fetch that failed once must not look like hardware that
+    lost a component.
+    """
+    missing = FakeCoordinator({"device_definitions": {}})
+    empty_ota = FakeCoordinator({"device_definitions": {"dev1": {}}})
+    known = FakeCoordinator({"device_definitions": definition(wifi={"verSw": "1"})})
+
+    assert firmware.reports_ota_modules(missing, "dev1") is False
+    assert firmware.reports_ota_modules(empty_ota, "dev1") is False
+    assert firmware.reports_ota_modules(known, "dev1") is True
+    # And the module genuinely is absent in the case we do know about.
+    assert firmware.has_ota_module(known, FakeDevice(), "mcu") is False


### PR DESCRIPTION
First of the four items queued: update entity, then localisation, then device triggers, then repairs, then discovery.

The firmware sensors already parsed everything an update entity needs, the running version, the offered version, and Tuya's `upgradeStatus`. It sat in a diagnostic sensor's attributes, where nothing surfaces it and no automation is likely to find it. As `update` entities the same information appears in Settings, Updates, next to every other device on the system.

## Read-only, deliberately

`UpdateEntityFeature.INSTALL` is not set. Probing the Tuya upgrade endpoints with a Philips third-party OAuth token returns `PERMISSION_DENIED` for `thing.m.device.upgrade.info` and `.auto.switch.get`, so this integration cannot start an update even when one is offered. `release_summary` says to install from the Philips app instead. An install button that always fails is worse than no button.

`latest_version` falls back to the installed version rather than `None` when nothing is on offer, so a feeder that is simply current reads "up to date" rather than "unknown", which looks like a fault.

## Shared lookups

The version resolution moves to `firmware.py`, used by the sensors, the update entities, and the stale-entity sweep, which was carrying a third copy of the MCU detection. `sensor.py` gets shorter and still returns the full raw OTA record in its attributes, with Tuya's own key names, so existing templates keep working.

An MCU entity is only created for hardware that reports an MCU module, and the stale sweep now removes both MCU entities for hardware that does not, not just the sensor.

## First tests in the repository

`tests/test_firmware.py`, 20 cases, mostly on the fallback chain in `installed_version`. That chain matters more than it looks: the OTA endpoints are unauthorised for most third-party logins, so the version comes from a different rung on almost every install, and a broken rung is invisible when you only have one device to look at.

`firmware.py` imports nothing from Home Assistant, so the suite runs in about ten milliseconds with nothing but pytest installed. The new `test.yml` workflow reflects that: no Home Assistant install, no `pyproject.toml` changes.

## How this was verified

The dev instance cannot load the config entry at the moment, because the account's refresh token has expired (`invalid_grant` on refresh), so a live end-to-end check is not possible until it is re-authenticated. Instead:

- The Home Assistant API surface was checked inside the running container: `UpdateDeviceClass.FIRMWARE`, `UpdateEntityFeature(0)`, and the property names the entity overrides all exist on `UpdateEntity` in 2026.7.
- The lookups were driven against the real feeder's data shape, taken from what this device actually reports:

```
real device -> installed: 111.06.24 | offered: None | mcu present: False
with an offer -> installed: 111.06.24 | offered: 111.07.00
```

So this feeder gets a single wifi update entity reading "up to date", and would report `111.07.00` if Philips ever ships one.

**Still unverified:** the entity rendering in the Settings, Updates panel, which needs the re-auth.